### PR TITLE
Github Actions: add upstream sync workflow

### DIFF
--- a/.github/workflows/upstream_sync.yml
+++ b/.github/workflows/upstream_sync.yml
@@ -1,0 +1,17 @@
+name: Sync with upstream
+
+on:
+  schedule:
+    - cron: '0 17 * * *' # every day, by the end of the day, trigger the sync
+  workflow_dispatch: # on button click
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: tgymnich/fork-sync@v1.3
+        with:
+          github_token: ${{ secrets.GH_TOKEN }}
+          owner: auterion
+          base: master
+          head: master


### PR DESCRIPTION
Allows to automatically create a PR to sync with upstream mavlink/mavlink. Approval will be required to merge the PR, so making it safe to use.