### PR TITLE
message_definitions: auterion: add MAV_CMD_COMPONENT_CONTROL cmd and COMPONENT_CONTROL enum

### DIFF
--- a/message_definitions/v1.0/auterion.xml
+++ b/message_definitions/v1.0/auterion.xml
@@ -29,7 +29,7 @@
         <description>Control the state or functionality of system components.</description>
         <param index="1" label="Component ID" enum="MAV_COMPONENT">Component ID of the system component to be controlled.</param>
         <param index="2" label="Component Control Type" enum="COMPONENT_CONTROL">Control command type being sent to the system component.</param>
-        <param index="3">Empty.</param>
+        <param index="3" label="Component Instance ID" minValue="0" maxValue="1" increment="1">Component instance, when there is more than one instance per component.</param>
         <param index="4">Empty.</param>
         <param index="5">Empty.</param>
         <param index="6">Empty.</param>

--- a/message_definitions/v1.0/auterion.xml
+++ b/message_definitions/v1.0/auterion.xml
@@ -2,6 +2,40 @@
 <mavlink>
   <include>common.xml</include>
   <dialect>2</dialect>
-  <enums/>
+  <enums>
+    <enum name="COMPONENT_CONTROL">
+      <description>Type of controls or state changes for system components.</description>
+      <entry value="1" name="COMPONENT_CONTROL_START">
+        <description>Start/turn-on system component.</description>
+      </entry>
+      <entry value="2" name="COMPONENT_CONTROL_STOP">
+        <description>Stop/turn-off system component.</description>
+      </entry>
+      <entry value="3" name="COMPONENT_CONTROL_RESTART">
+        <description>Restart/reboot system component.</description>
+      </entry>
+      <entry value="4" name="COMPONENT_CONTROL_RESTART_AND_KEEP_BL">
+        <description>Restart/reboot system component and keep it in the bootloader until upgraded.</description>
+      </entry>
+      <entry value="5" name="COMPONENT_CONTROL_ENABLE">
+        <description>Enable system component. Used to switch a system component from an idle state to an active state.</description>
+      </entry>
+      <entry value="6" name="COMPONENT_CONTROL_DISABLE">
+        <description>Disable system component. Used to switch a system component from an active state to an idle state.</description>
+      </entry>
+    </enum>
+    <enum name="MAV_CMD">
+      <entry value="248" name="MAV_CMD_COMPONENT_CONTROL" hasLocation="false" isDestination="false">
+        <description>Control the state or functionality of system components.</description>
+        <param index="1" label="Component ID" enum="MAV_COMPONENT">Component ID of the system component to be controlled.</param>
+        <param index="2" label="Component Control Type" enum="COMPONENT_CONTROL">Control command type being sent to the system component.</param>
+        <param index="3">Empty.</param>
+        <param index="4">Empty.</param>
+        <param index="5">Empty.</param>
+        <param index="6">Empty.</param>
+        <param index="7">Empty.</param>
+      </entry>
+    </enum>
+  </enums>
   <messages/>
 </mavlink>


### PR DESCRIPTION
This PR adds `MAV_CMD_COMPONENT_CONTROL`, a command that serves the purpose of controlling MAVLink system components. We can compare it with simplified version of `systemctl`, which is an utility that makes part of Linux `systemd`, but in this case it can interface with both HW components and also with system services identified by component ID (ex: `MAV_COMP_ID_PATHPLANNER` or `MAV_COMP_ID_OBSTACLE_AVOIDANCE`).

The type of control that can be used is mapped by the `COMPONENT_CONTROL` enumeration, which can be extended for other types of controls if required.

This command can be considered a replacement of `MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN`, as it provided more control options without restricting ourselves the the limited command fields.

The first usage of this command will be added in MAVSDK, in order to control mission computer services.