### PR TITLE
scripts: only generate auterion dialect

### DIFF
--- a/scripts/update_c_library.sh
+++ b/scripts/update_c_library.sh
@@ -60,13 +60,7 @@ rm -rf $CLIBRARY_PATH/*
 
 # generate new c headers
 echo -e "\0033[34mStarting to generate c headers\0033[0m\n"
-generate_headers development $1
-generate_headers ardupilotmega $1
 generate_headers auterion $1
-generate_headers matrixpilot $1
-generate_headers test $1
-generate_headers ASLUAV $1
-generate_headers standard $1
 mkdir -p $CLIBRARY_PATH/message_definitions
 cp message_definitions/v1.0/* $CLIBRARY_PATH/message_definitions/.
 echo -e "\0033[34mFinished generating c headers\0033[0m\n"


### PR DESCRIPTION
If we generate all the dialects we end up with a build error when trying
to use auterion/mavlink.h:

```
error: "MAVLINK_MESSAGE_INFO" redefined
```

By only generating auterion.xml we don't have that problem.