### PR TITLE
Generate common

### DIFF
--- a/scripts/update_c_library.sh
+++ b/scripts/update_c_library.sh
@@ -62,6 +62,7 @@ rm -rf $CLIBRARY_PATH/*
 echo -e "\0033[34mStarting to generate c headers\0033[0m\n"
 generate_headers auterion $1
 generate_headers ardupilotmega $1
+generate_headers common $1
 mkdir -p $CLIBRARY_PATH/message_definitions
 cp message_definitions/v1.0/* $CLIBRARY_PATH/message_definitions/.
 echo -e "\0033[34mFinished generating c headers\0033[0m\n"


### PR DESCRIPTION
Shouldn't we generate common, too? Otherwise some messages are missing.

For instance, https://github.com/mavlink/c_library_v2/blob/master/common/common.h#L775 does not appear in https://github.com/Auterion/c_library_v2/blob/master/common/common.h.

Or is that on purpose?