### PR TITLE
Add Payload Drop Message

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1314,6 +1314,16 @@
         <param index="6">Empty</param>
         <param index="7">Empty</param>
       </entry>
+      <entry value="116" name="MAV_CMD_CONDITION_PAYLOAD_DROP" hasLocation="false" isDestination="false">
+        <description>Drop a payload at current location, either via winch or a servo</description>
+        <param index="1" label="Timeout" units="s">Timeout after which the command will come to an end, regardless of receiving the Command Ack message or not</param>
+        <param index="2">Empty</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
       <entry value="159" name="MAV_CMD_CONDITION_LAST" hasLocation="false" isDestination="false">
         <description>NOP - This command is only used to mark the upper limit of the CONDITION commands in the enumeration</description>
         <param index="1">Empty</param>


### PR DESCRIPTION
## Context
This is part of the PR : https://github.com/Auterion/PX4_firmware_private/pull/1922

## What is in this PR
- This message will simply drop the payload & wait for the
acknowledgement.
- This is different from the 'MAV_CMD_NAV_PAYLOAD_PLACE', as it doesn't navigate to the specific location, but simply drops the payload, and wait for the Acknowledgement (hence, it has NAV_CMD_CONDITION_* prefix, since it needs to wait)