### PR TITLE
VTOL-987 Mavlink - define ToF message and send GCS location

### DIFF
--- a/message_definitions/v1.0/auterion.xml
+++ b/message_definitions/v1.0/auterion.xml
@@ -35,6 +35,18 @@
       <field type="uint8_t" name="queue_size"> Local (message sender) number of packets in buffer.</field>
       <field type="uint8_t" name="air_time" units="%">Local (message sender) percentage of time the radio is transmitting.</field>
     </message>
+    <message id="445" name="BEACON_POSITION">
+      <description>Position of and distance to a Beacon.
+      </description>
+      <field type="uint32_t" name="beacon_id">Unique Beacon ID</field>
+      <field type="int32_t" name="latitude" units="degE7">Latitude (WGS84), in degrees * 1E7</field>
+      <field type="int32_t" name="longitude" units="degE7">Longitude (WGS84), in degrees * 1E7</field>
+      <field type="float" name="altitude" units="m">Altitude (MSL), in meters</field>
+      <field type="float" name="distance" units="m">Distance to the Beacon, in meters</field>
+      <field type="int32_t" name="delay" units="ms">Time between generating the value and request, in milliseconds</field>
+      <field type="uint8_t" name="gps_status">Status indicating the quality of the GPS Data. 0=invalid 1=lat long valid, alt invalid 2=valid</field>
+      <field type="int32_t" name="link_quality">Value indicating the Signal to noise ratio (in units of dB)</field>
+    </message>
     <message id="460" name="RADIATION_DETECTOR_COUNTS">
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -493,14 +493,14 @@
     <message id="445" name="BEACON_POSITION">
       <description>Position of and distance to a Beacon.
       </description>
-      <field type="uint32_t" name="beacon_id">ID of the Beacon</field>
-      <field type="int32_t" name="latitude" units="degE7">Latitude (WGS84)</field>
-      <field type="int32_t" name="longitude" units="degE7">Longitude (WGS84)</field>
-      <field type="float" name="altitude" units="m">Altitude (MSL)</field>
-      <field type="float" name="distance" units="m">Distance to the Beacon</field>
-      <field type="int32_t" name="delay" units="ms">Time between generating the value and request</field>
+      <field type="uint32_t" name="beacon_id">Unique Beacon ID</field>
+      <field type="int32_t" name="latitude" units="degE7">Latitude (WGS84), in degrees * 1E7</field>
+      <field type="int32_t" name="longitude" units="degE7">Longitude (WGS84), in degrees * 1E7</field>
+      <field type="float" name="altitude" units="m">Altitude (MSL), in meters</field>
+      <field type="float" name="distance" units="m">Distance to the Beacon, in meters</field>
+      <field type="int32_t" name="delay" units="ms">Time between generating the value and request, in milliseconds</field>
       <field type="uint8_t" name="gps_status">Status indicating the quality of the GPS Data. 0=invalid 1=lat long valid, alt invalid 2=valid</field>
-      <field type="int32_t" name="link_quality">Value indicating the Signal to noise ratio (in units of dB) NaN is invalid</field>
+      <field type="int32_t" name="link_quality">Value indicating the Signal to noise ratio (in units of dB)</field>
     </message>
   </messages>
 </mavlink>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -490,17 +490,5 @@
       <field type="uint8_t" name="base_mode" enum="MAV_MODE_FLAG" display="bitmask">System mode bitmap.</field>
       <field type="uint32_t" name="custom_mode">A bitfield for use for autopilot-specific flags</field>
     </message>
-    <message id="445" name="BEACON_POSITION">
-      <description>Position of and distance to a Beacon.
-      </description>
-      <field type="uint32_t" name="beacon_id">Unique Beacon ID</field>
-      <field type="int32_t" name="latitude" units="degE7">Latitude (WGS84), in degrees * 1E7</field>
-      <field type="int32_t" name="longitude" units="degE7">Longitude (WGS84), in degrees * 1E7</field>
-      <field type="float" name="altitude" units="m">Altitude (MSL), in meters</field>
-      <field type="float" name="distance" units="m">Distance to the Beacon, in meters</field>
-      <field type="int32_t" name="delay" units="ms">Time between generating the value and request, in milliseconds</field>
-      <field type="uint8_t" name="gps_status">Status indicating the quality of the GPS Data. 0=invalid 1=lat long valid, alt invalid 2=valid</field>
-      <field type="int32_t" name="link_quality">Value indicating the Signal to noise ratio (in units of dB)</field>
-    </message>
   </messages>
 </mavlink>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -496,11 +496,11 @@
       <field type="uint32_t" name="beacon_id">ID of the Beacon</field>
       <field type="int32_t" name="latitude" units="degE7">Latitude (WGS84)</field>
       <field type="int32_t" name="longitude" units="degE7">Longitude (WGS84)</field>
-      <field type="int32_t" name="altitude" units="mm">Altitude (MSL). Positive for up.</field>
-      <field type="int32_t" name="distance" units="mE-7">Distance to the Beacon</field>
+      <field type="float" name="altitude" units="m">Altitude (MSL)</field>
+      <field type="float" name="distance" units="m">Distance to the Beacon</field>
       <field type="int32_t" name="delay" units="ms">Time between generating the value and request</field>
       <field type="uint8_t" name="gps_status">Status indicating the quality of the GPS Data. 0=invalid 1=lat long valid, alt invalid 2=valid</field>
-      <field type="int32_t" name="link_quality">Value indicating the Signal to noise ratio</field>
+      <field type="int32_t" name="link_quality">Value indicating the Signal to noise ratio (in units of dB) NaN is invalid</field>
     </message>
   </messages>
 </mavlink>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -497,7 +497,7 @@
       <field type="int32_t" name="latitude" units="degE7">Latitude (WGS84)</field>
       <field type="int32_t" name="longitude" units="degE7">Longitude (WGS84)</field>
       <field type="int32_t" name="altitude" units="mm">Altitude (MSL). Positive for up.</field>
-      <field type="int32_t" name="distance" units="">Distance to the Beacon</field>
+      <field type="int32_t" name="distance" units="mE-7">Distance to the Beacon</field>
       <field type="int32_t" name="delay" units="ms">Time between generating the value and request</field>
       <field type="uint8_t" name="gps_status">Status indicating the quality of the GPS Data. 0=invalid 1=lat long valid, alt invalid 2=valid</field>
       <field type="int32_t" name="link_quality">Value indicating the Signal to noise ratio</field>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -490,5 +490,17 @@
       <field type="uint8_t" name="base_mode" enum="MAV_MODE_FLAG" display="bitmask">System mode bitmap.</field>
       <field type="uint32_t" name="custom_mode">A bitfield for use for autopilot-specific flags</field>
     </message>
+    <message id="445" name="BEACON_POSITION">
+      <description>Position of and distance to a Beacon.
+      </description>
+      <field type="uint32_t" name="beacon_id">ID of the Beacon</field>
+      <field type="int32_t" name="latitude" units="degE7">Latitude (WGS84)</field>
+      <field type="int32_t" name="longitude" units="degE7">Longitude (WGS84)</field>
+      <field type="int32_t" name="altitude" units="mm">Altitude (MSL). Positive for up.</field>
+      <field type="int32_t" name="distance" units="">Distance to the Beacon</field>
+      <field type="int32_t" name="delay" units="ms">Time between generating the value and request</field>
+      <field type="uint8_t" name="gps_status">Status indicating the quality of the GPS Data. 0=invalid 1=lat long valid, alt invalid 2=valid</field>
+      <field type="int32_t" name="link_quality">Value indicating the Signal to noise ratio</field>
+    </message>
   </messages>
 </mavlink>


### PR DESCRIPTION
https://auterion.atlassian.net/browse/VTOL-987

Add a message to log distance to a beacon (radio) and its position, to auterion messages.
This message is part of a bigger scope to improve position estimation in GPS denied environments.