### PR TITLE
Add control handoff messages for multiple GCS

### DIFF
--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -379,6 +379,60 @@
         <param index="7" reserved="true"/>
       </entry>
     </enum>
+    <enum name="CURRENT_CONTROL_ENTITY">
+      <description>List of the currently active control entity.</description>
+      <entry value="0" name="CURRENT_CONTROL_ENTITY_NONE">
+        <description>Setting if no entity has control ownership.</description>
+      </entry>
+      <entry value="1" name="CURRENT_CONTROL_ENTITY_OWNER">
+        <description>Setting if the receiving GCS is the control entity.</description>
+      </entry>
+      <entry value="2" name="CURRENT_CONTROL_ENTITY_OTHER">
+        <description>Setting if a GCS other than the receiving GCS is the control entity.</description>
+      </entry>
+    </enum>
+    <enum name="CONTROL_TARGET_REQUEST">
+      <description>Selection of control target for changing ownership.</description>
+      <entry value="0" name="CONTROL_TARGET_ALL">
+        <description>Request change control ownership of both flight control and payload control.</description>
+      </entry>
+      <entry value="1" name="CONTROL_TARGET_FLIGHT">
+        <description>Request change control ownership of the flight control.</description>
+      </entry>
+      <entry value="2" name="CONTROL_TARGET_PAYLOAD">
+        <description>Request change control ownership of the payload control.</description>
+      </entry>
+    </enum>
+    <enum name="CONTROL_REQUEST_ERROR_CODE">
+      <description>Error code for the control request response.</description>
+      <entry value="0" name="CONTROL_REQUEST_PROCESSED">
+        <description>Code indicating successful processing of the request.</description>
+      </entry>
+      <entry value="1" name="CONTROL_REQUEST_DENIED">
+        <description>Error code indicating that the control request has been denied by the target system.</description>
+      </entry>
+      <entry value="2" name="CONTROL_REQUEST_HANDOFF_TIMEOUT">
+        <description>Error Code indicating timeout on the handoff request.</description>
+      </entry>
+      <entry value="3" name="CONTROL_REQUEST_DENIED_CONCURRENT">
+        <description>Error Code indicating another control request is in process.</description>
+      </entry>
+      <entry value="4" name="CONTROL_REQUEST_NO_CONTROL_AUTHORITY">
+        <description>Error Code indicating no enough authority to take control ownership.</description>
+      </entry>
+      <entry value="5" name="CONTROL_REQUEST_NO_PRIORITY_AUTHORITY">
+        <description>Error Code indicating no enough priority authority control ownership.</description>
+      </entry>
+    </enum>
+    <enum name="HANDOFF_DECISION">
+      <description>Decision of the GCS to a handoff request.</description>
+      <entry value="0" name="HANDOFF_DECISION_ACCEPT">
+        <description>Decision to accept the handoff and release control ownership.</description>
+      </entry>
+      <entry value="1" name="HANDOFF_DECISION_DENIED">
+        <description>Decision to deny the handoff request and keep control ownership.</description>
+      </entry>
+    </enum>
   </enums>
   <messages>
     <!-- Transactions for parameter protocol -->
@@ -500,6 +554,51 @@
       <field type="uint8_t" name="standard_mode" enum="MAV_STANDARD_MODE">Standard mode.</field>
       <field type="uint8_t" name="base_mode" enum="MAV_MODE_FLAG" display="bitmask">System mode bitmap.</field>
       <field type="uint32_t" name="custom_mode">A bitfield for use for autopilot-specific flags</field>
+    </message>
+    <message id="441" name="CONTROL_STATUS">
+      <description>Status message indicating the currently active flight control and payload control entity.
+        This message should typically be send from the system at a low frequency as well as after a control ownership change to all connected GCS. 
+      </description>
+      <field type="uint8_t" name="current_flight_controller" enum="CURRENT_CONTROL_ENTITY">Current flight control entity.</field>
+      <field type="uint8_t" name="current_payload_controller" enum="CURRENT_CONTROL_ENTITY">Current payload control entity.</field>
+    </message>
+    <message id="442" name="REQUEST_CONTROL">
+      <description>Request the flight control and/or the payload control of the target system by a GCS.
+        The message can be used in a multi GCS environment. A GCS can request the control ownership of the target system. 
+      </description>
+      <field type="uint8_t" name="control_target" enum="CONTROL_TARGET_REQUEST">Control target to change to own ownership.</field>
+      <field type="uint8_t" name="request_priority" default="0">Priority of the control request. If the priority is higher than the priority
+        of the current control entity, control is given without handoff request. 
+        The priority request should be authenticated on the target system before granting this privilegs. Default value of 0.</field>
+      <field type="char[10]" name="requester_id">Identification of the control entity requesting ownership.</field>
+      <field type="char[50]" name="reason">Reason for taking ownership.</field>
+    </message>
+    <message id="443" name="REQUEST_CONTROL_ACK">
+      <description>Error code response of the target system to the control ownership request.
+      </description>
+      <field type="uint8_t" name="error_code" enum="CONTROL_REQUEST_ERROR_CODE">Error code response.</field>
+    </message>
+    <message id="444" name="RELEASE_CONTROL">
+      <description>Release the previously aquired control. 
+        The message can be used in a multi GCS environment to release the control of the target system. 
+        This message is ignored when the GCS is not the current active control entity of the control target.
+      </description>
+      <field type="uint8_t" name="control_target" enum="CONTROL_TARGET_REQUEST">Control target to release own ownership.</field>
+    </message>
+    <message id="445" name="REQUEST_HANDOFF">
+      <description>Request handoff of current control entity.
+        This message is send from the system to the current active control entity to request the handoff of the control target to another GCS.
+      </description>
+      <field type="uint8_t" name="control_target" enum="CONTROL_TARGET_REQUEST">Control target to handoff control ownership.</field>
+      <field type="char[10]" name="requester_id">Identification of the control entity requesting ownership.</field>
+      <field type="char[50]" name="reason">Reason from the control entity requesting ownership.</field>
+    </message>
+    <message id="446" name="HANDOFF_RESPOND">
+      <description>Handoff response to handoff request. 
+        This message is the response from the GCS in control to the handoff request.
+      </description>
+      <field type="uint8_t" name="control_target" enum="CONTROL_TARGET_REQUEST">Control target to handoff.</field>
+      <field type="uint8_t" name="handoff_decision" enum="HANDOFF_DECISION">Control target decision.</field>
     </message>
   </messages>
 </mavlink>


### PR DESCRIPTION
### Problem to Solve
In a multi GCS environment, only on GCS should be able to control the system. All other GCS should only act as observers. As an observer, you can still receive telemetry and payload stream, get the parameters and the mission, but cannot command the vehicle and change the parameters and mission. In order to set which GCS is in control, new message sets needs to be created.

### Proposed solution
The proposed solution is detailed as:
- Control can be given for the Flight control and/or the payload
- A control status message is sent from the system at a constant frequency and when the control has been changed. The message is sent to all connected GCS and defines if the GCS is in control, another GCS is in control or none is in control.
- A GCS is always first connected as an obsever.
- A GCS can request control with a message. 
-- If the current system is not controlled yet, the request is always accepted.
-- If another GCS is in control, the system will ask the controlling GCS for a handoff.
-- A GCS can forcefully take over the control, if the request control priority is higher than the current priority. (The system should verify if the GCS is allowed to sent the priority level).
- A GCS can also release the control again if it has ownership. In this case, the System sets the controller to None again.
- A response code is send to the GCS requesting access giving a detail of the request in terms of error codes.
A communication diagram is shown here:
[Mavlink_distributed_GCS.drawio.pdf](https://github.com/mavlink/mavlink/files/10734670/Mavlink_distributed_GCS.drawio.pdf)
