### PR TITLE
APX4-3139 - Add VELOCITY_LIMITS msg

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -7289,8 +7289,8 @@
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Temporary limits for horizontal speed, vertical speed and yaw rate to slow down the vehicle from the default configuration during operation. This message should be streamed at 1Hz while the lower limits apply. The consumer implements a timeout and returns to default limits in case the stream is lost. Accelerations are automatically adjusted accordingly.</description>
-      <field type="float" name="horizontal_velocity_limit" default="NaN" units="m/s">Limit for horizontal movement in local inertial north east frame. NaN: Use vehicle default speed</field>
-      <field type="float" name="vertical_velocity_limit" default="NaN" units="m/s">Limit for vertical movement in local inertial down frame. NaN: Use vehicle default speed</field>
+      <field type="float" name="horizontal_velocity_limit" default="NaN" units="m/s">Limit for horizontal movement in MAV_FRAME LOCAL. NaN: Use vehicle default speed</field>
+      <field type="float" name="vertical_velocity_limit" default="NaN" units="m/s">Limit for vertical movement in MAV_FRAME LOCAL. NaN: Use vehicle default speed</field>
       <field type="float" name="yaw_rate_limit" default="NaN" units="rad/s">Limit for vehicle turn rate around its yaw axis. NaN: Use vehicle default rate</field>
     </message>
     <message id="360" name="ORBIT_EXECUTION_STATUS">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -7302,7 +7302,7 @@
     <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
     <!-- TODO: Make sure the ID and naming are appropiate -->
     <message id="354" name="VELOCITY_LIMITS">
-      <description>Setpoint of horizontal speed, vertical speed and yaw rate.</description>
+      <description>Temporary limits for horizontal speed, vertical speed and yaw rate to slow down the vehicle from the default configuration during operation. This message should be streamed at 1Hz while the lower limits apply. The consumer implements a timeout and returns to default limits in case the stream is lost. Accelerations are automatically adjusted accordingly.</description>
       <field type="float" name="horizontal_speed" units="m/s">Horizontal speed in m/s</field>
       <field type="float" name="vertical_speed" units="m/s">Vertical speed in m/s</field>
       <field type="float" name="yaw_rate" units="rad/s">Yaw rate in rad/s</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4940,6 +4940,19 @@
         <description>Mission has executed all mission items.</description>
       </entry>
     </enum>
+    <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+    <enum name="VELOCITY_LIMITS_MASK" bitmask="true">
+      <description>These encode velocity setpoints that are currently enabled.</description>
+      <entry value="1" name="VELOCITY_LIMITS_MASK_HORIZONTAL">
+        <description>Accept horizontal speed setpoint</description>
+      </entry>
+      <entry value="2" name="VELOCITY_LIMITS_MASK_VERTICAL">
+        <description>Accept vertical speed setpoint</description>
+      </entry>
+      <entry value="4" name="VELOCITY_LIMITS_MASK_YAW">
+        <description>Accept yaw rate setpoint</description>
+      </entry>
+    </enum>
   </enums>
   <messages>
     <message id="1" name="SYS_STATUS">
@@ -7284,6 +7297,15 @@
       <field type="uint16_t" name="array_id" instance="true">Unique ID used to discriminate between arrays</field>
       <extensions/>
       <field type="float[58]" name="data">data</field>
+    </message>
+    <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+    <!-- TODO: Make sure the ID and naming are appropiate -->
+    <message id="354" name="VELOCITY_LIMITS">
+      <description>Setpoint of horizontal speed, vertical speed and yaw rate.</description>
+      <field type="float" name="horizontal_speed" units="m/s">Horizontal speed in m/s</field>
+      <field type="float" name="vertical_speed" units="m/s">Vertical speed in m/s</field>
+      <field type="float" name="yaw_rate" units="rad/s">Yaw rate in rad/s</field>
+      <field type="uint8_t" name="type_mask" enum="VELOCITY_LIMITS_MASK" display="bitmask">Bitmap to indicate which velocity setpoint should be considered.</field>
     </message>
     <message id="360" name="ORBIT_EXECUTION_STATUS">
       <wip/>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4940,19 +4940,6 @@
         <description>Mission has executed all mission items.</description>
       </entry>
     </enum>
-    <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-    <enum name="VELOCITY_LIMITS_MASK" bitmask="true">
-      <description>These encode velocity setpoints that are currently enabled.</description>
-      <entry value="1" name="VELOCITY_LIMITS_MASK_HORIZONTAL">
-        <description>Accept horizontal speed setpoint</description>
-      </entry>
-      <entry value="2" name="VELOCITY_LIMITS_MASK_VERTICAL">
-        <description>Accept vertical speed setpoint</description>
-      </entry>
-      <entry value="4" name="VELOCITY_LIMITS_MASK_YAW">
-        <description>Accept yaw rate setpoint</description>
-      </entry>
-    </enum>
   </enums>
   <messages>
     <message id="1" name="SYS_STATUS">
@@ -7298,15 +7285,13 @@
       <extensions/>
       <field type="float[58]" name="data">data</field>
     </message>
-    <wip/>
-    <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-    <!-- TODO: Make sure the ID and naming are appropiate -->
     <message id="354" name="VELOCITY_LIMITS">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Temporary limits for horizontal speed, vertical speed and yaw rate to slow down the vehicle from the default configuration during operation. This message should be streamed at 1Hz while the lower limits apply. The consumer implements a timeout and returns to default limits in case the stream is lost. Accelerations are automatically adjusted accordingly.</description>
-      <field type="float" name="horizontal_speed" units="m/s">Horizontal speed in m/s</field>
-      <field type="float" name="vertical_speed" units="m/s">Vertical speed in m/s</field>
-      <field type="float" name="yaw_rate" units="rad/s">Yaw rate in rad/s</field>
-      <field type="uint8_t" name="type_mask" enum="VELOCITY_LIMITS_MASK" display="bitmask">Bitmap to indicate which velocity setpoint should be considered.</field>
+      <field type="float" name="horizontal_velocity_limit" default="NaN" units="m/s">Limit for horizontal movement in local inertial north east frame. NaN: Use vehicle default speed</field>
+      <field type="float" name="vertical_velocity_limit" default="NaN" units="m/s">Limit for vertical movement in local inertial down frame. NaN: Use vehicle default speed</field>
+      <field type="float" name="yaw_rate_limit" default="NaN" units="rad/s">Limit for vehicle turn rate around its yaw axis. NaN: Use vehicle default rate</field>
     </message>
     <message id="360" name="ORBIT_EXECUTION_STATUS">
       <wip/>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -7298,6 +7298,7 @@
       <extensions/>
       <field type="float[58]" name="data">data</field>
     </message>
+    <wip/>
     <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
     <!-- TODO: Make sure the ID and naming are appropiate -->
     <message id="354" name="VELOCITY_LIMITS">


### PR DESCRIPTION
[jira](https://auterion.atlassian.net/browse/APX4-3139?atlOrigin=eyJpIjoiODVkYzg2YmFjZGUwNDU1OGJiNjA4NmM0ZjZhZDdlMDciLCJwIjoiaiJ9)
This pr is part of a bigger scope which aims to enable "slow mode" on a vehicle. 
The velocity_limits message consists of: 

 * horizontal velocity limit
 * vertical velocity limit 
 * yaw rate limit
 * ~Bitmask that describes which one of the above is enabled/disabled~
 * ~Timeout after which the velocity setpoint won't be considered anymore~