### PR TITLE
Release/2.7 mavlink

### DIFF
--- a/message_definitions/v1.0/auterion.xml
+++ b/message_definitions/v1.0/auterion.xml
@@ -9,19 +9,6 @@
         <description>Initiate a precision hold at a distance above a target.</description>
         <param index="1" label="Height above target"/>
       </entry>
-      <entry value="353" name="MAV_CMD_DO_SET_SPEED_LIMITS" hasLocation="false" isDestination="false">
-        <wip/>
-        <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-        <description>Enable/Disable speed limits and set constraints.</description>
-        <param index="1" label="Enable" minValue="0" maxValue="1" increment="1">Enable (1: enable, 0:disable).</param>
-        <param index="2">Empty.</param>
-        <param index="3">Empty.</param>
-        <param index="4">Empty.</param>
-        <param index="5">Empty.</param>
-        <param index="6">Empty.</param>
-        <param index="7">Empty.</param>
-      </entry>
-    </enum>
   </enums>
   <messages>
     <message id="420" name="RADIO_STATUS_EXTENSIONS">

--- a/message_definitions/v1.0/auterion.xml
+++ b/message_definitions/v1.0/auterion.xml
@@ -11,6 +11,14 @@
       </entry>
   </enums>
   <messages>
+    <message id="354" name="VELOCITY_LIMITS">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+      <description>Limit the maximum horizontal speed, vertical speed and yaw rate of the vehicle.</description>
+      <field type="float" name="horizontal_velocity" default="NaN" units="m/s">Limit for horizontal movement in MAV_FRAME LOCAL. NaN: Use vehicle default speed.</field>
+      <field type="float" name="vertical_velocity" default="NaN" units="m/s">Limit for vertical movement in MAV_FRAME LOCAL. NaN: Use vehicle default speed.</field>
+      <field type="float" name="yaw_rate" default="NaN" units="rad/s">Limit for vehicle turn rate around its yaw axis. NaN: Use vehicle default rate.</field>
+    </message>
     <message id="420" name="RADIO_STATUS_EXTENSIONS">
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->

--- a/message_definitions/v1.0/auterion.xml
+++ b/message_definitions/v1.0/auterion.xml
@@ -9,6 +9,7 @@
         <description>Initiate a precision hold at a distance above a target.</description>
         <param index="1" label="Height above target"/>
       </entry>
+    </enum>
   </enums>
   <messages>
     <message id="354" name="VELOCITY_LIMITS">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5507,6 +5507,9 @@
       <field type="uint8_t" name="enabled_extensions">Set bits to 1 to indicate which of the following extension fields contain valid data: bit 0: pitch, bit 1: roll.</field>
       <field type="int16_t" name="s">Pitch-only-axis, normalized to the range [-1000,1000]. Generally corresponds to pitch on vehicles with additional degrees of freedom. Valid if bit 0 of enabled_extensions field is set. Set to 0 if invalid.</field>
       <field type="int16_t" name="t">Roll-only-axis, normalized to the range [-1000,1000]. Generally corresponds to roll on vehicles with additional degrees of freedom. Valid if bit 1 of enabled_extensions field is set. Set to 0 if invalid.</field>
+      <field type="float" name="vertical_velocity_constraint">Scaling down the speed and acceleration in vertical direction.</field>
+      <field type="float" name="horizontal_velocity_constraint">Scaling down the speed and acceleration in horizontal direction.</field>
+      <field type="float" name="yaw_rate_constraint">Scaling down the yaw rate.</field>
     </message>
     <message id="70" name="RC_CHANNELS_OVERRIDE">
       <description>The RAW values of the RC channels sent to the MAV to override info received from the RC radio. The standard PPM modulation is as follows: 1000 microseconds: 0%, 2000 microseconds: 100%. Individual receivers/transmitters might violate this specification.  Note carefully the semantic differences between the first 8 channels and the subsequent channels</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -7318,6 +7318,14 @@
       <extensions/>
       <field type="float[58]" name="data">data</field>
     </message>
+    <message id="354" name="VELOCITY_LIMITS">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+      <description>Temporary limits for horizontal speed, vertical speed and yaw rate to slow down the vehicle from the default configuration during operation. This message should be streamed at 1Hz while the lower limits apply. The consumer implements a timeout and returns to default limits in case the stream is lost. Accelerations are automatically adjusted accordingly.</description>
+      <field type="float" name="horizontal_velocity_limit" default="NaN" units="m/s">Limit for horizontal movement in MAV_FRAME LOCAL. NaN: Use vehicle default speed</field>
+      <field type="float" name="vertical_velocity_limit" default="NaN" units="m/s">Limit for vertical movement in MAV_FRAME LOCAL. NaN: Use vehicle default speed</field>
+      <field type="float" name="yaw_rate_limit" default="NaN" units="rad/s">Limit for vehicle turn rate around its yaw axis. NaN: Use vehicle default rate</field>
+    </message>
     <message id="360" name="ORBIT_EXECUTION_STATUS">
       <wip/>
       <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -7316,14 +7316,6 @@
       <extensions/>
       <field type="float[58]" name="data">data</field>
     </message>
-    <message id="354" name="VELOCITY_LIMITS">
-      <wip/>
-      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-      <description>Limit the horizontal speed, vertical speed and yaw rate of the vehicle. This message should be streamed at 1Hz while the limits apply. The consumer implements a timeout and returns to default limits in case the stream is lost. Accelerations are limited accordingly.</description>
-      <field type="float" name="horizontal_velocity" default="NaN" units="m/s">Limit for horizontal movement in MAV_FRAME LOCAL. NaN: Use vehicle default speed</field>
-      <field type="float" name="vertical_velocity" default="NaN" units="m/s">Limit for vertical movement in MAV_FRAME LOCAL. NaN: Use vehicle default speed</field>
-      <field type="float" name="yaw_rate" default="NaN" units="rad/s">Limit for vehicle turn rate around its yaw axis. NaN: Use vehicle default rate</field>
-    </message>
     <message id="360" name="ORBIT_EXECUTION_STATUS">
       <wip/>
       <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -7319,10 +7319,10 @@
     <message id="354" name="VELOCITY_LIMITS">
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-      <description>Temporary limits for horizontal speed, vertical speed and yaw rate to slow down the vehicle from the default configuration during operation. This message should be streamed at 1Hz while the lower limits apply. The consumer implements a timeout and returns to default limits in case the stream is lost. Accelerations are automatically adjusted accordingly.</description>
-      <field type="float" name="horizontal_velocity_limit" default="NaN" units="m/s">Limit for horizontal movement in MAV_FRAME LOCAL. NaN: Use vehicle default speed</field>
-      <field type="float" name="vertical_velocity_limit" default="NaN" units="m/s">Limit for vertical movement in MAV_FRAME LOCAL. NaN: Use vehicle default speed</field>
-      <field type="float" name="yaw_rate_limit" default="NaN" units="rad/s">Limit for vehicle turn rate around its yaw axis. NaN: Use vehicle default rate</field>
+      <description>Limit the horizontal speed, vertical speed and yaw rate of the vehicle. This message should be streamed at 1Hz while the limits apply. The consumer implements a timeout and returns to default limits in case the stream is lost. Accelerations are limited accordingly.</description>
+      <field type="float" name="horizontal_velocity" default="NaN" units="m/s">Limit for horizontal movement in MAV_FRAME LOCAL. NaN: Use vehicle default speed</field>
+      <field type="float" name="vertical_velocity" default="NaN" units="m/s">Limit for vertical movement in MAV_FRAME LOCAL. NaN: Use vehicle default speed</field>
+      <field type="float" name="yaw_rate" default="NaN" units="rad/s">Limit for vehicle turn rate around its yaw axis. NaN: Use vehicle default rate</field>
     </message>
     <message id="360" name="ORBIT_EXECUTION_STATUS">
       <wip/>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5507,9 +5507,7 @@
       <field type="uint8_t" name="enabled_extensions">Set bits to 1 to indicate which of the following extension fields contain valid data: bit 0: pitch, bit 1: roll.</field>
       <field type="int16_t" name="s">Pitch-only-axis, normalized to the range [-1000,1000]. Generally corresponds to pitch on vehicles with additional degrees of freedom. Valid if bit 0 of enabled_extensions field is set. Set to 0 if invalid.</field>
       <field type="int16_t" name="t">Roll-only-axis, normalized to the range [-1000,1000]. Generally corresponds to roll on vehicles with additional degrees of freedom. Valid if bit 1 of enabled_extensions field is set. Set to 0 if invalid.</field>
-      <field type="float" name="vertical_velocity_constraint">Scaling down the speed and acceleration in vertical direction.</field>
-      <field type="float" name="horizontal_velocity_constraint">Scaling down the speed and acceleration in horizontal direction.</field>
-      <field type="float" name="yaw_rate_constraint">Scaling down the yaw rate.</field>
+      <field type="int16_t[6]" name="aux">Auxiliary fields.</field>
     </message>
     <message id="70" name="RC_CHANNELS_OVERRIDE">
       <description>The RAW values of the RC channels sent to the MAV to override info received from the RC radio. The standard PPM modulation is as follows: 1000 microseconds: 0%, 2000 microseconds: 100%. Individual receivers/transmitters might violate this specification.  Note carefully the semantic differences between the first 8 channels and the subsequent channels</description>


### PR DESCRIPTION
This PR extends the MANUAL_CONTROL message to allow the transmission of additional information over the MAVLink message. Currently, the focus is on velocity constraints. Additionally, it introduces a new message, VELOCITY_LIMITS, which serves the same purpose (passing information about velocity constraints) as the extended fields in MANUAL_CONTROL. This enhancement provides the flexibility to combine two sources of constraints.