### PR TITLE
[2.7] common: remove MANUAL_CONTROL.aux extension for now

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5507,7 +5507,6 @@
       <field type="uint8_t" name="enabled_extensions">Set bits to 1 to indicate which of the following extension fields contain valid data: bit 0: pitch, bit 1: roll.</field>
       <field type="int16_t" name="s">Pitch-only-axis, normalized to the range [-1000,1000]. Generally corresponds to pitch on vehicles with additional degrees of freedom. Valid if bit 0 of enabled_extensions field is set. Set to 0 if invalid.</field>
       <field type="int16_t" name="t">Roll-only-axis, normalized to the range [-1000,1000]. Generally corresponds to roll on vehicles with additional degrees of freedom. Valid if bit 1 of enabled_extensions field is set. Set to 0 if invalid.</field>
-      <field type="int16_t[6]" name="aux">Auxiliary fields.</field>
     </message>
     <message id="70" name="RC_CHANNELS_OVERRIDE">
       <description>The RAW values of the RC channels sent to the MAV to override info received from the RC radio. The standard PPM modulation is as follows: 1000 microseconds: 0%, 2000 microseconds: 100%. Individual receivers/transmitters might violate this specification.  Note carefully the semantic differences between the first 8 channels and the subsequent channels</description>


### PR DESCRIPTION
to first suggest it upstream and make sure we have a final definition for production use.

Order:
- [x] 1. This pr
- [x] 2. APX4 using this pr in https://github.com/Auterion/PX4_firmware_private/pull/2367
- [x] 2. Suggest the aux extension upstream in https://github.com/mavlink/mavlink/pull/2031
- [ ] 3. Up to date definition in https://github.com/Auterion/mavlink/pull/215
- [ ] 4. Up to date APX4 implementation in https://github.com/Auterion/PX4_firmware_private/pull/2366