### PR TITLE
Revert update_c_library.sh

### DIFF
--- a/scripts/update_c_library.sh
+++ b/scripts/update_c_library.sh
@@ -60,23 +60,8 @@ rm -rf $CLIBRARY_PATH/*
 
 # generate new c headers
 echo -e "\0033[34mStarting to generate c headers\0033[0m\n"
-generate_headers all $1
 generate_headers auterion $1
-generate_headers test $1
-generate_headers storm32 $1
 generate_headers ardupilotmega $1
-generate_headers csAirLink $1
-generate_headers uAvionix $1
-generate_headers cubepilot $1
-generate_headers ualberta $1
-generate_headers paparazzi $1
-generate_headers ASLUAV $1
-generate_headers matrixpilot $1
-generate_headers python_array_test $1
-generate_headers development $1
-generate_headers common $1
-generate_headers standard $1
-generate_headers minimal $1
 mkdir -p $CLIBRARY_PATH/message_definitions
 cp message_definitions/v1.0/* $CLIBRARY_PATH/message_definitions/.
 echo -e "\0033[34mFinished generating c headers\0033[0m\n"


### PR DESCRIPTION
In a recent automatic upstream merge the ordering of the xml list got messed up. How it was before:

auterion.xml
ardupilotmega.xml

why?
auterion.xml includes ras_a.xml
ras_a.xml includes develop.xml

ardupilotmega.xml includes common.xml (+ uavionix, icarous, cubepilot, csairlink xmls) common.xml includes standard.xml
standard.xml includes minimal.xml

This PR reverts to our previous sequence which should generate the headers we want. But... man... can there be a less convoluted way?? @TSC21 any ideas? (doesnt need to be done for this PR)