### PR TITLE
Fix include tree, duplicate message ids, and ci tests

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -65,7 +65,7 @@ jobs:
           sudo apt install -y python3 python3-pip
       - name: Install MAVLink headers
         run: |
-          cmake -Bbuild -H. -DCMAKE_INSTALL_PREFIX=install
+          cmake -Bbuild -H. -DMAVLINK_DIALECT=auterion -DCMAKE_INSTALL_PREFIX=install
           cmake --build build --target install
       - name: Build example
         run: |

--- a/examples/c/udp_example.c
+++ b/examples/c/udp_example.c
@@ -12,7 +12,7 @@
 #include <sys/socket.h>
 #include <time.h>
 
-#include <mavlink/common/mavlink.h>
+#include <mavlink/auterion/mavlink.h>
 
 
 void receive_some(int socket_fd, struct sockaddr_in* src_addr, socklen_t* src_addr_len, bool* src_addr_set);

--- a/message_definitions/v1.0/auterion.xml
+++ b/message_definitions/v1.0/auterion.xml
@@ -159,7 +159,7 @@
       <field type="uint8_t" name="control_target" enum="CONTROL_TARGET_REQUEST">Control target to handoff.</field>
       <field type="uint8_t" name="handoff_decision" enum="HANDOFF_DECISION">Control target decision.</field>
     </message>
-    <message id="445" name="BEACON_POSITION">
+    <message id="447" name="BEACON_POSITION">
       <description>Position of and distance to a Beacon.
       </description>
       <field type="uint32_t" name="beacon_id">Unique Beacon ID</field>

--- a/message_definitions/v1.0/ras_a.xml
+++ b/message_definitions/v1.0/ras_a.xml
@@ -9,7 +9,7 @@
   <enums>
     <enum name="MAV_TYPE">
       <description>MAVLINK component type reported in HEARTBEAT message.</description>
-      <entry value="43" name="MAV_TYPE_GENERIC_COMPONENT">
+      <entry value="50" name="MAV_TYPE_GENERIC_COMPONENT">
         <description>Generic component which implements the generic component attribute discovery and control interface through mavlink parameter exchange.</description>
       </entry>
     </enum>

--- a/scripts/update_c_library.sh
+++ b/scripts/update_c_library.sh
@@ -61,7 +61,6 @@ rm -rf $CLIBRARY_PATH/*
 # generate new c headers
 echo -e "\0033[34mStarting to generate c headers\0033[0m\n"
 generate_headers auterion $1
-generate_headers ardupilotmega $1
 mkdir -p $CLIBRARY_PATH/message_definitions
 cp message_definitions/v1.0/* $CLIBRARY_PATH/message_definitions/.
 echo -e "\0033[34mFinished generating c headers\0033[0m\n"


### PR DESCRIPTION
Need to additionally remove ardupilotmega xml... not sure how this worked before with it included.

Fixes lingering wrongness from #226 

Include tree:
auterion.xml includes ras_a.xml
ras_a.xml includes development.xml
development.xml includes common.xml

**HOLD:**
still need to resolve:
- [x] ras_a enum duplicate @TSC21 I need your input here. what do we do about this? This MAV_TYPE is likely commonly used.. and is actually in common.xml https://mavlink.io/en/messages/common.html#MAV_TYPE_GENERIC_MULTIROTOR
```
Merged enum MAV_COMPONENT
ERROR: Duplicate enum values:
	MAV_TYPE.MAV_TYPE_GENERIC_MULTIROTOR = 43 @ /home/thomas/git/PX4_firmware_private/src/modules/mavlink/mavlink/message_definitions/v1.0/minimal.xml:203
	MAV_TYPE.MAV_TYPE_GENERIC_COMPONENT = 43 @ /home/thomas/git/PX4_firmware_private/src/modules/mavlink/mavlink/message_definitions/v1.0/ras_a.xml:12
```
(@TSC21 edited: it's done - check https://github.com/Auterion/mavlink/pull/227/commits/9a291322468d4332f2d9a2a6e2ca02cfae97930a).
- [x] BEACON id duplicate came in with #179 
```
ERROR: Duplicate message id 445 for BEACON_POSITION (message_definitions/v1.0/auterion.xml:162) also used by REQUEST_HANDOFF (message_definitions/v1.0/auterion.xml:147)
```
- [x] Can we also add a ci check that tries to generate the headers and see's if it fails? the only reason i found these errors now is by running it locally and seeing it fail.. (@TSC21 edited: it's done - check https://github.com/Auterion/mavlink/pull/227/commits/c0ef57e7813e4a73edcabb531aab63714ce7df24).