### PR TITLE
Bring back CELLULAR_STATUS

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -7251,14 +7251,27 @@
     </message>
     <!-- cellular status information -->
     <message id="334" name="CELLULAR_STATUS">
-      <description>Report current used cellular network status</description>
+      <description>Report current used cellular network status.
+                   Note that the extensions are still an open PR here and subject to change slightly: https://github.com/mavlink/mavlink/pull/1945</description>
       <field type="uint8_t" name="status" enum="CELLULAR_STATUS_FLAG">Cellular modem status</field>
       <field type="uint8_t" name="failure_reason" enum="CELLULAR_NETWORK_FAILED_REASON">Failure reason when status in in CELLULAR_STATUS_FLAG_FAILED</field>
       <field type="uint8_t" name="type" enum="CELLULAR_NETWORK_RADIO_TYPE">Cellular network radio type: gsm, cdma, lte...</field>
-      <field type="uint8_t" name="quality" invalid="UINT8_MAX">Signal quality in percent. If unknown, set to UINT8_MAX</field>
+      <field type="uint8_t" name="quality" invalid="UINT8_MAX">Signal quality in percent. May be used for Received Signal Strength Indicator (RSSI). If unknown, set to UINT8_MAX</field>
       <field type="uint16_t" name="mcc" invalid="UINT16_MAX">Mobile country code. If unknown, set to UINT16_MAX</field>
       <field type="uint16_t" name="mnc" invalid="UINT16_MAX">Mobile network code. If unknown, set to UINT16_MAX</field>
       <field type="uint16_t" name="lac" invalid="0">Location area code. If unknown, set to 0</field>
+      <extensions/>
+      <field type="uint8_t" name="band_number" invalid="0">(WIP) LTE frequency band number.</field>
+      <field type="float" name="band_frequency" units="MHz" invalid="0">(WIP) LTE radio frequency.</field>
+      <field type="uint16_t" name="channel_number" invalid="0">(WIP) The channel number (CN). Absolute radio-frequency (ARFCN) / E-UTRA (EARFCN) / UTRA (UARFCN) / New radio (NR_CH).</field>
+      <field type="float" name="rx_level" units="dBm" invalid="0">(WIP) On 3G is Received Signal Code Power (RSCP). On LTE Reference Signal Received Power (RSRP). On 5G  is New Radio Reference Signal Received Power (NR_RSRQ).</field>
+      <field type="float" name="tx_level" units="dBm" invalid="0">(WIP) Transmitter (modem) signal absolute power level.</field>
+      <field type="float" name="rx_quality" units="dBm" invalid="0">(WIP) On 3G is Receiver Quality (RxQual). On LTE is Reference Signal Received Quality (RSRQ). On 5G is New radio Reference Signal Received Quality (NR_RSRQ).</field>
+      <field type="uint32_t" name="link_tx_rate" units="KiB/s" invalid="0">(WIP) Download rate.</field>
+      <field type="uint32_t" name="link_rx_rate" units="KiB/s" invalid="0">(WIP) Upload rate.</field>
+      <field type="uint16_t" name="ber" invalid="0">(WIP) The bit error rate (BER) is determined by comparing the erroneous bits received with the total number of bits received. It is a ratio.</field>
+      <field type="uint8_t" name="id" instance="true" invalid="0">(WIP) Cellular instance number. Indexed from 1. Matches index in corresponding CELLULAR_MODEM_INFORMATION message.</field>
+      <field type="char[9]" name="cell_tower_id" invalid="0">(WIP) ID of the currently connected cell tower. This must be NULL terminated if the length is less than 9 human-readable chars, and without the null termination (NULL) byte if the length is exactly 9 chars.</field>
     </message>
     <message id="335" name="ISBD_LINK_STATUS">
       <description>Status of the Iridium SBD link.</description>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -414,6 +414,19 @@
       <field type="uint16_t" name="data_rate" units="MiB/s">WiFi network data rate. Set to UINT16_MAX if data_rate information is not supplied.</field>
       <field type="uint8_t" name="security" enum="WIFI_NETWORK_SECURITY">WiFi network security type.</field>
     </message>
+    <message id="337" name="CELLULAR_MODEM_INFORMATION">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+      <description> This message is still WIP, but was tentatively accepted upstream: https://github.com/mavlink/mavlink/pull/1945.
+                    Cellular modem device information. This contains static information about a modem and should be sent at low rate. Note that the dynamic information about the connection is provided in an associated CELLULAR_STATUS message.</description>
+      <field type="uint8_t" name="id" instance="true">Modem instance number. Indexed from 1. Matches index in corresponding CELLULAR_STATUS message.</field>
+      <field type="uint64_t" name="imei" invalid="NULL">Unique Modem International Mobile Equipment Identity Number.</field>
+      <field type="uint64_t" name="imsi" invalid="NULL">Current SIM International mobile subscriber identity.</field>
+      <field type="char[10]" name="modem_id" invalid="[0]">Unique id for modem. This must be NULL terminated if the length is less than 10 human-readable chars, and without the null termination (NULL) byte if the length is exactly 10 chars.</field>
+      <field type="char[20]" name="iccid" invalid="[0]">Integrated Circuit Card Identification Number of SIM Card.  This must be NULL terminated if the length is less than 20 human-readable chars, and without the null termination (NULL) byte if the length is exactly 20 chars.</field>
+      <field type="char[24]" name="firmware" invalid="[0]">The firmware version installed on the modem. This must be NULL terminated if the length is less than 24 human-readable chars, and without the null termination (NULL) byte if the length is exactly 24 chars. The format is not intended for display.</field>
+      <field type="char[50]" name="modem_model" invalid="[0]">Modem model name.  This must be NULL terminated if the length is less than 50 human-readable chars, and without the null termination (NULL) byte if the length is exactly 50 chars.</field>
+    </message>
     <message id="354" name="SET_VELOCITY_LIMITS">
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->


### PR DESCRIPTION
Upstream PR that we want to merge soon:
https://github.com/mavlink/mavlink/pull/1945

Merged the changes into Auterion's MAVLink fork almost a year ago:
https://github.com/Auterion/mavlink/pull/182

Then removed 3 months ago:
https://github.com/Auterion/mavlink/pull/220/files

But we need it now already. So let's bring it back.
My apologies, and I will make sure we can merge the upstream PR soon.