### PR TITLE
USV messages for for Auterion dialect

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "pymavlink"]
 	path = pymavlink
-	url = https://github.com/ardupilot/pymavlink.git
+	url = https://github.com/Auterion/pymavlink.git

--- a/message_definitions/v1.0/auterion.xml
+++ b/message_definitions/v1.0/auterion.xml
@@ -25,6 +25,42 @@
         <param index="2" label="Horizontal Step" minValue="-32768" maxValue="32767" increment="1">Horizontal adjustment in steps relative to the current position. Negative values shift the target left; positive values shift it right.</param>
         <param index="3" label="Vertical Step" minValue="-32768" maxValue="32767" increment="1">Vertical adjustment in steps relative to the current position. Negative values shift the target upward; positive values shift it downward.</param>
       </entry>
+      <entry value="670" name="MAV_CMD_DO_CONTROL_TAKEOVER" hasLocation="false" isDestination="false">
+        <wip/>
+        <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+        <description>Commands to take over control from the safety driver. This command cannot give control to safety driver.</description>
+        <param index="1">Empty</param>
+        <param index="2">Empty</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="671" name="MAV_CMD_DO_ENGINE_LEG_TRIM" hasLocation="false" isDestination="false">
+        <wip/>
+        <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+        <description>Set engine leg trim position. Can execute trim for individual legs or all legs at once.</description>
+        <param index="1" label="Engine bitmask" minValue="0" increment="1" maxValue="255">Engine leg selection bitmask.</param>
+        <param index="2" label="Direction" minValue="0" maxValue="1" increment="1">Executes engine leg trimming for all selected engines(0: Down, 1:up)</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="672" name="MAV_CMD_DO_SET_ENGINE_STATE" hasLocation="false" isDestination="false">
+        <wip/>
+        <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+        <description>Commands the desired state for vehicle engines.</description>
+        <param index="1" label="Engine bitmask" minValue="0" increment="1" maxValue="255">Engine selection bitmask.</param>
+        <param index="2" label="Command" minValue="0" increment="1" maxValue="4">Commanded engine state for the selected engines.</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
     </enum>
     <enum name="MAV_COMPONENT">
       <entry value="110" name="MAV_COMP_ID_TRACKER">
@@ -120,6 +156,126 @@
       </entry>
       <entry value="2" name="PARAM_TRANSACTION_ACTION_CANCEL">
         <description>Cancel the current parameter transaction.</description>
+      </entry>
+    </enum>
+    <enum name="ENGINE_LEG_TRIM_STATE">
+      <description>Defines the position status of a engine leg trim.</description>
+      <entry value="0" name="ENGINE_LEG_TRIM_NONE">
+        <description>ENGINE_LEF_TRIM_NONE indicates no engine leg trim system is present.</description>
+      </entry>
+      <entry value="1" name="ENGINE_LEG_TRIM_STOWED">
+        <description>ENGINE_LEG_TRIM_STOWED means leg is lifted and the engine should not be started.</description>
+      </entry>
+      <entry value="2" name="ENGINE_LEG_TRIM_CRUISE">
+        <description>ENGINE_LEG_TRIM_CRUISE defines the active operational position of the engine leg.</description>
+      </entry>
+      <entry value="3" name="ENGINE_LEG_TRIM_FAULT">
+        <description>ENGINE_LEG_TRIM_FAULT indicates a faulty state in the engine leg trimming system.</description>
+      </entry>
+    </enum>
+    <enum name="RUDDER_STATE">
+      <description>Defines health state of a rudder.</description>
+      <entry value="0" name="RUDDER_NONE">
+        <description>RUDDER_NONE indicates no rudder system is present.</description>
+      </entry>
+      <entry value="1" name="RUDDER_OK">
+        <description>RUDDER_OK indicates the rudder is operating correctly.</description>
+      </entry>
+      <entry value="2" name="RUDDER_FAULT">
+        <description>RUDDER_FAULT indicates a fault in the rudder system.</description>
+      </entry>
+    </enum>
+    <enum name="ENGINE_STATE">
+      <description>Defines the operation state of an engine.</description>
+      <entry value="0" name="ENGINE_NONE">
+        <description>ENGINE_NONE indicates engine is not running and ignition is off.</description>
+      </entry>
+      <entry value="1" name="ENGINE_STOPPED">
+        <description>ENGINE_STOPPED indicates the engine is not running, but ignition is on.</description>
+      </entry>
+      <entry value="2" name="ENGINE_STARTING">
+        <description>ENGINE_STARTING indicates the engine is starting.</description>
+      </entry>
+      <entry value="3" name="ENGINE_RUNNING">
+        <description>ENGINE_RUNNING indicates the engine is running.</description>
+      </entry>
+      <entry value="4" name="ENGINE_FAULT">
+        <description>ENGINE_FAULT indicates a fault in the engine system.</description>
+      </entry>
+    </enum>
+    <enum name="TRANSMISSION_STATE">
+      <description>Defines the operation state of a transmission.</description>
+      <entry value="0" name="TRANSMISSION_NONE">
+        <description>TRANSMISSION_NONE indicates no transmission system is present.</description>
+      </entry>
+      <entry value="1" name="TRANSMISSION_NEUTRAL">
+        <description>TRANSMISSION_NEUTRAL indicates the transmission is in neutral.</description>
+      </entry>
+      <entry value="2" name="TRANSMISSION_FORWARD">
+        <description>TRANSMISSION_FORWARD indicates the transmission is in forward.</description>
+      </entry>
+      <entry value="3" name="TRANSMISSION_REVERSE">
+        <description>TRANSMISSION_REVERSE indicates the transmission is in reverse.</description>
+      </entry>
+      <entry value="4" name="TRANSMISSION_FAULT">
+        <description>TRANSMISSION_FAULT indicates a fault in the transmission system.</description>
+      </entry>
+    </enum>
+    <enum name="FLUID_TANK_TYPE">
+      <description>Defines the type of fluid contained in a tank.</description>
+      <entry value="0" name="TANK_TYPE_FUEL">
+        <description>TANK_TYPE_FUEL indicates the tank contains fuel.</description>
+      </entry>
+      <entry value="1" name="TANK_TYPE_WATER">
+        <description>TANK_TYPE_WATER indicates the tank contains fresh water.</description>
+      </entry>
+      <entry value="2" name="TANK_TYPE_GRAY_WATER">
+        <description>TANK_TYPE_GRAY_WATER indicates the tank contains gray water.</description>
+      </entry>
+      <entry value="3" name="TANK_TYPE_LIVE_WELL">
+        <description>TANK_TYPE_LIVE_WELL indicates the tank is a live well.</description>
+      </entry>
+      <entry value="4" name="TANK_TYPE_OIL">
+        <description>TANK_TYPE_OIL indicates the tank contains engine or hydraulic oil.</description>
+      </entry>
+      <entry value="5" name="TANK_TYPE_BLACK_WATER">
+        <description>TANK_TYPE_BLACK_WATER indicates the tank contains black water.</description>
+      </entry>
+    </enum>
+    <enum name="SPEED_WATER_REFERENCED_TYPE">
+      <description>Defines the type of sensor used for measuring speed through water.</description>
+      <entry value="0" name="REFERENCED_TYPE_PADDLE_WHEEL">
+        <description>REFERENCED_TYPE_PADDLE_WHEEL indicates speed is measured using a paddle wheel sensor.</description>
+      </entry>
+      <entry value="1" name="REFERENCED_TYPE_PITOT_TUBE">
+        <description>REFERENCED_TYPE_PITOT_TUBE indicates speed is measured using a pitot tube.</description>
+      </entry>
+      <entry value="2" name="REFERENCED_TYPE_DOPPLER">
+        <description>REFERENCED_TYPE_DOPPLER indicates speed is measured using a Doppler-based sensor.</description>
+      </entry>
+      <entry value="3" name="REFERENCED_TYPE_CORRELATION">
+        <description>REFERENCED_TYPE_CORRELATION indicates speed is measured using a correlation-based sensor.</description>
+      </entry>
+      <entry value="4" name="REFERENCED_TYPE_ELECTRO_MAGNETIC">
+        <description>REFERENCED_TYPE_ELECTRO_MAGNETIC indicates speed is measured using an electromagnetic flow sensor.</description>
+      </entry>
+    </enum>
+    <enum name="WIND_REFERENCE">
+      <description>Specifies the frame of reference used for wind direction and speed measurements.</description>
+       <entry value="0" name="REFERENCE_TRUE">
+        <description>REFERENCE_TRUE Wind referenced to geographic (true) North.</description>
+      </entry>
+      <entry value="1" name="REFERENCE_MAGNETIC">
+        <description>REFERENCE_MAGNETIC Wind referenced to magnetic North.</description>
+      </entry>
+      <entry value="2" name="REFERENCE_APPARENT">
+        <description>REFERENCE_APPARENT Apparent wind relative to the vessel.</description>
+      </entry>
+      <entry value="3" name="REFERENCE_TRUE_BOAT_REFERENCED">
+        <description>REFERENCE_TRUE_BOAT_REFERENCED True wind direction relative to the boat's heading, corrected for vessel movement but not Earth-referenced..</description>
+      </entry>
+      <entry value="4" name="REFERENCE_TRUE_WATER_REFERENCED">
+        <description>REFERENCE_TRUE_WATER_REFERENCED True wind direction relative to the water surface.</description>
       </entry>
     </enum>
   </enums>
@@ -237,6 +393,78 @@
       <field type="float[9]" name="ned_homography_matrix">3x3 matrix for NED (North-East-Down) homography transform of the image. Row-major order.</field>
       <field type="char[100]" name="error_message">Optional error message in case of failure. Max length 100 characters.</field>
     </message>
+    <message id="666" name="BOAT_ACTUATOR_STATUS">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+      <description>Boat actuator status reports status and position of all boat control surfaces (currently rudders, engine leg trims).</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="uint8_t[6]" name="engine_leg_trim_state" enum="ENGINE_LEG_TRIM_STATE">Engine leg trim state.</field>
+      <field type="float[6]" name="engine_leg_trim_position" units="deg">Engine leg trim position.</field>
+      <field type="uint8_t[6]" name="rudder_state" enum="RUDDER_STATE">Rudder state.</field>
+      <field type="float[6]" name="rudder_position" units="deg">Rudder position.</field>
+    </message>
+    <message id="667" name="BOAT_ENGINE_STATUS">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+      <description>Boat engine status reports status and position of all boat engines.</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="uint8_t[6]" name="engine_state" enum="ENGINE_STATE">Engine state.</field>
+      <field type="uint8_t[6]" name="engine_load" units="%">Engine load.</field>
+      <field type="uint16_t[6]" name="engine_rpm" units="rpm">Engine RPM.</field>
+      <field type="float" name="fuel_consumption_rate" units="l/h">Fuel consumption rate.</field>
+      <field type="float[6]" name="oil_pressure" units="kPa">Engine oil pressure.</field>
+      <field type="uint8_t[6]" name="throttle_position" units="%">Throttle position.</field>
+      <field type="float[6]" name="engine_coolant_temperature" units="degC">Engine coolant temperature.</field>
+      <field type="uint8_t[6]" name="transmission_state" enum="TRANSMISSION_STATE">Transmission state.</field>
+    </message>
+    <message id="668" name="BOAT_BATTERY_STATUS">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+      <description>Boat battery status reports battery status as interpreted through NMEA2000.</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="uint8_t" name="instance">Battery instance.</field>
+      <field type="float" name="voltage" units="V">Battery voltage.</field>
+      <field type="float" name="current" units="A">Battery current.</field>
+      <field type="float" name="temperature" units="K">Battery temperature.</field>
+    </message>
+    <message id="669" name="BOAT_FLUID_LEVEL">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+      <description>Boat fluid level reports fluid levels as interpreted through NMEA2000.</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="uint8_t" name="instance">Fluid tank instance.</field>
+      <field type="uint8_t" name="type" enum="FLUID_TANK_TYPE">Fluid tank type.</field>
+      <field type="float" name="level" units="%">Fluid level in percentage of full tank.</field>
+      <field type="float" name="capacity" units="l">Fluid capacity left in tank in liters.</field>
+    </message>
+    <message id="670" name="BOAT_SPEED">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+      <description>Boat speed reports speeds as interpreted through NMEA2000.</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="float" name="speed_water_referenced" units="m/s">Speed water referenced.</field>
+      <field type="float" name="speed_ground_referenced" units="m/s">Speed ground referenced.</field>
+      <field type="uint8_t" name="speed_water_referenced_type" enum="SPEED_WATER_REFERENCED_TYPE">Speed water referenced type.</field>
+      <field type="uint8_t" name="speed_direction">Speed direction.</field>
+    </message>
+    <message id="671" name="BOAT_WATER_DEPTH">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+      <description>Boat water depth reports water depth as interpreted through NMEA2000.</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="float" name="depth" units="m">Depth below transducer.</field>
+      <field type="float" name="offset" units="m">Distance between transducer and surface (positive) or keel (negative).</field>
+      <field type="float" name="range" units="m">Max measurement range.</field>
+    </message>
+    <message id="672" name="BOAT_WIND_DATA">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+      <description>Boat wind data reports wind data as interpreted through NMEA2000..</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="uint8_t" name="reference" enum="WIND_REFERENCE">Wind reference.</field>
+      <field type="float" name="wind_speed" units="m/s">Wind speed.</field>
+      <field type="float" name="wind_angle" units="rad">Wind angle.</field>
+    </message>
     <!-- PIXEL_TO_LLA END -->
     <message id="13000" name="MOTOR_INFO">
       <description> Contains information about a motor. </description>
@@ -247,18 +475,18 @@
     </message>
     <message id="13441" name="CONTROL_STATUS_REPORT">
       <description>Status message indicating the currently active flight control and payload control entity.
-        This message should typically be send from the system at a low frequency as well as after a control ownership change to all connected GCS. 
+        This message should typically be send from the system at a low frequency as well as after a control ownership change to all connected GCS.
       </description>
       <field type="uint8_t" name="current_flight_controller" enum="CURRENT_CONTROL_ENTITY">Current flight control entity.</field>
       <field type="uint8_t" name="current_payload_controller" enum="CURRENT_CONTROL_ENTITY">Current payload control entity.</field>
     </message>
     <message id="13442" name="REQUEST_CONTROL">
       <description>Request the flight control and/or the payload control of the target system by a GCS.
-        The message can be used in a multi GCS environment. A GCS can request the control ownership of the target system. 
+        The message can be used in a multi GCS environment. A GCS can request the control ownership of the target system.
       </description>
       <field type="uint8_t" name="control_target" enum="CONTROL_TARGET_REQUEST">Control target to change to own ownership.</field>
       <field type="uint8_t" name="request_priority" default="0">Priority of the control request. If the priority is higher than the priority
-        of the current control entity, control is given without handoff request. 
+        of the current control entity, control is given without handoff request.
         The priority request should be authenticated on the target system before granting this privilegs. Default value of 0.</field>
       <field type="char[40]" name="requester_id">Identification of the control entity requesting ownership.</field>
       <field type="char[100]" name="reason">Reason for taking ownership.</field>
@@ -270,8 +498,8 @@
       <field type="uint8_t" name="error_code" enum="CONTROL_REQUEST_ERROR_CODE">Error code response.</field>
     </message>
     <message id="13444" name="RELEASE_CONTROL">
-      <description>Release the previously aquired control. 
-        The message can be used in a multi GCS environment to release the control of the target system. 
+      <description>Release the previously aquired control.
+        The message can be used in a multi GCS environment to release the control of the target system.
         This message is ignored when the GCS is not the current active control entity of the control target.
       </description>
       <field type="uint8_t" name="control_target" enum="CONTROL_TARGET_REQUEST">Control target to release own ownership.</field>
@@ -285,7 +513,7 @@
       <field type="char[100]" name="reason">Reason from the control entity requesting ownership.</field>
     </message>
     <message id="13446" name="HANDOFF_RESPOND">
-      <description>Handoff response to handoff request. 
+      <description>Handoff response to handoff request.
         This message is the response from the GCS in control to the handoff request.
       </description>
       <field type="uint8_t" name="control_target" enum="CONTROL_TARGET_REQUEST">Control target to handoff.</field>

--- a/message_definitions/v1.0/auterion.xml
+++ b/message_definitions/v1.0/auterion.xml
@@ -437,7 +437,7 @@
       <field type="uint8_t" name="speed_water_referenced_type" enum="SPEED_WATER_REFERENCED_TYPE">Speed water referenced type.</field>
       <field type="uint8_t" name="speed_direction">Speed direction.</field>
     </message>
-    <message id="670" name="WATER_DEPTH">
+    <message id="670" name="WATER_DEPTH_RAW">
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Water depth measurement data as interpreted through NMEA2000.</description>

--- a/message_definitions/v1.0/auterion.xml
+++ b/message_definitions/v1.0/auterion.xml
@@ -25,7 +25,7 @@
         <param index="2" label="Horizontal Step" minValue="-32768" maxValue="32767" increment="1">Horizontal adjustment in steps relative to the current position. Negative values shift the target left; positive values shift it right.</param>
         <param index="3" label="Vertical Step" minValue="-32768" maxValue="32767" increment="1">Vertical adjustment in steps relative to the current position. Negative values shift the target upward; positive values shift it downward.</param>
       </entry>
-      <entry value="670" name="MAV_CMD_DO_CONTROL_TAKEOVER" hasLocation="false" isDestination="false">
+      <entry value="13670" name="MAV_CMD_DO_CONTROL_TAKEOVER" hasLocation="false" isDestination="false">
         <wip/>
         <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
         <description>Commands to take over control from the safety driver. This command cannot give control to safety driver.</description>
@@ -37,7 +37,7 @@
         <param index="6">Empty</param>
         <param index="7">Empty</param>
       </entry>
-      <entry value="671" name="MAV_CMD_DO_ENGINE_LEG_TRIM" hasLocation="false" isDestination="false">
+      <entry value="13671" name="MAV_CMD_DO_ENGINE_LEG_TRIM" hasLocation="false" isDestination="false">
         <wip/>
         <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
         <description>Set engine leg trim position. Can execute trim for individual legs or all legs at once.</description>
@@ -49,7 +49,7 @@
         <param index="6">Empty</param>
         <param index="7">Empty</param>
       </entry>
-      <entry value="672" name="MAV_CMD_DO_SET_ENGINE_STATE" hasLocation="false" isDestination="false">
+      <entry value="13672" name="MAV_CMD_DO_SET_ENGINE_STATE" hasLocation="false" isDestination="false">
         <wip/>
         <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
         <description>Commands the desired state for vehicle engines.</description>
@@ -393,68 +393,6 @@
       <field type="float[9]" name="ned_homography_matrix">3x3 matrix for NED (North-East-Down) homography transform of the image. Row-major order.</field>
       <field type="char[100]" name="error_message">Optional error message in case of failure. Max length 100 characters.</field>
     </message>
-    <message id="666" name="BOAT_ACTUATOR_STATUS">
-      <wip/>
-      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-      <description>Boat actuator status reports status and position of all boat control surfaces (currently rudders, engine leg trims).</description>
-      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
-      <field type="uint8_t[6]" name="engine_leg_trim_state" enum="ENGINE_LEG_TRIM_STATE">Engine leg trim state.</field>
-      <field type="float[6]" name="engine_leg_trim_position" units="deg">Engine leg trim position.</field>
-      <field type="uint8_t[6]" name="rudder_state" enum="RUDDER_STATE">Rudder state.</field>
-      <field type="float[6]" name="rudder_position" units="deg">Rudder position.</field>
-    </message>
-    <message id="667" name="BOAT_ENGINE_STATUS">
-      <wip/>
-      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-      <description>Boat engine status reports status and position of all boat engines.</description>
-      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
-      <field type="uint8_t[6]" name="engine_state" enum="ENGINE_STATE">Engine state.</field>
-      <field type="uint8_t[6]" name="engine_load" units="%">Engine load.</field>
-      <field type="uint16_t[6]" name="engine_rpm" units="rpm">Engine RPM.</field>
-      <field type="float" name="fuel_consumption_rate" units="l/h">Fuel consumption rate.</field>
-      <field type="float[6]" name="oil_pressure" units="kPa">Engine oil pressure.</field>
-      <field type="uint8_t[6]" name="throttle_position" units="%">Throttle position.</field>
-      <field type="float[6]" name="engine_coolant_temperature" units="degC">Engine coolant temperature.</field>
-      <field type="uint8_t[6]" name="transmission_state" enum="TRANSMISSION_STATE">Transmission state.</field>
-    </message>
-    <message id="668" name="FLUID_LEVEL">
-      <wip/>
-      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-      <description>Boat fluid level reports fluid levels as interpreted through NMEA2000.</description>
-      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
-      <field type="uint8_t" name="instance">Fluid tank instance.</field>
-      <field type="uint8_t" name="type" enum="FLUID_TANK_TYPE">Fluid tank type.</field>
-      <field type="float" name="level" units="%">Fluid level in percentage of full tank.</field>
-      <field type="float" name="capacity" units="l">Fluid capacity left in tank in liters.</field>
-    </message>
-    <message id="669" name="VESSEL_SPEED">
-      <wip/>
-      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-      <description>Vessel speed measurement as interpreted through NMEA2000.</description>
-      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
-      <field type="float" name="speed_water_referenced" units="m/s">Speed water referenced.</field>
-      <field type="float" name="speed_ground_referenced" units="m/s">Speed ground referenced.</field>
-      <field type="uint8_t" name="speed_water_referenced_type" enum="SPEED_WATER_REFERENCED_TYPE">Speed water referenced type.</field>
-      <field type="uint8_t" name="speed_direction">Speed direction.</field>
-    </message>
-    <message id="670" name="WATER_DEPTH_RAW">
-      <wip/>
-      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-      <description>Water depth measurement data as interpreted through NMEA2000.</description>
-      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
-      <field type="float" name="depth" units="m">Depth below transducer.</field>
-      <field type="float" name="offset" units="m">Distance between transducer and surface (positive) or keel (negative).</field>
-      <field type="float" name="range" units="m">Max measurement range.</field>
-    </message>
-    <message id="671" name="WIND_DATA_RAW">
-      <wip/>
-      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-      <description>Wind data measurement message as interpreted through NMEA2000.</description>
-      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
-      <field type="uint8_t" name="reference" enum="WIND_REFERENCE">Wind reference.</field>
-      <field type="float" name="wind_speed" units="m/s">Wind speed.</field>
-      <field type="float" name="wind_angle" units="rad">Wind angle.</field>
-    </message>
     <!-- PIXEL_TO_LLA END -->
     <message id="13000" name="MOTOR_INFO">
       <description> Contains information about a motor. </description>
@@ -515,5 +453,69 @@
       </description>
       <field type="char[32]" name="uuid">uuid of the sender.</field>
     </message>
+    <!-- Boat specific MAVLink-->
+    <message id="13666" name="BOAT_ACTUATOR_STATUS">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+      <description>Boat actuator status reports status and position of all boat control surfaces (currently rudders, engine leg trims).</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="uint8_t[6]" name="engine_leg_trim_state" enum="ENGINE_LEG_TRIM_STATE">Engine leg trim state.</field>
+      <field type="float[6]" name="engine_leg_trim_position" units="deg">Engine leg trim position.</field>
+      <field type="uint8_t[6]" name="rudder_state" enum="RUDDER_STATE">Rudder state.</field>
+      <field type="float[6]" name="rudder_position" units="deg">Rudder position.</field>
+    </message>
+    <message id="13667" name="BOAT_ENGINE_STATUS">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+      <description>Boat engine status reports status and position of all boat engines.</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="uint8_t[6]" name="engine_state" enum="ENGINE_STATE">Engine state.</field>
+      <field type="uint8_t[6]" name="engine_load" units="%">Engine load.</field>
+      <field type="uint16_t[6]" name="engine_rpm" units="rpm">Engine RPM.</field>
+      <field type="float" name="fuel_consumption_rate" units="l/h">Fuel consumption rate.</field>
+      <field type="float[6]" name="oil_pressure" units="kPa">Engine oil pressure.</field>
+      <field type="uint8_t[6]" name="throttle_position" units="%">Throttle position.</field>
+      <field type="float[6]" name="engine_coolant_temperature" units="degC">Engine coolant temperature.</field>
+      <field type="uint8_t[6]" name="transmission_state" enum="TRANSMISSION_STATE">Transmission state.</field>
+    </message>
+    <message id="13668" name="FLUID_LEVEL">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+      <description>Boat fluid level reports fluid levels as interpreted through NMEA2000.</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="uint8_t" name="instance">Fluid tank instance.</field>
+      <field type="uint8_t" name="type" enum="FLUID_TANK_TYPE">Fluid tank type.</field>
+      <field type="float" name="level" units="%">Fluid level in percentage of full tank.</field>
+      <field type="float" name="capacity" units="l">Fluid capacity left in tank in liters.</field>
+    </message>
+    <message id="13669" name="VESSEL_SPEED">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+      <description>Vessel speed measurement as interpreted through NMEA2000.</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="float" name="speed_water_referenced" units="m/s">Speed water referenced.</field>
+      <field type="float" name="speed_ground_referenced" units="m/s">Speed ground referenced.</field>
+      <field type="uint8_t" name="speed_water_referenced_type" enum="SPEED_WATER_REFERENCED_TYPE">Speed water referenced type.</field>
+      <field type="uint8_t" name="speed_direction">Speed direction.</field>
+    </message>
+    <message id="13670" name="WATER_DEPTH_RAW">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+      <description>Water depth measurement data as interpreted through NMEA2000.</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="float" name="depth" units="m">Depth below transducer.</field>
+      <field type="float" name="offset" units="m">Distance between transducer and surface (positive) or keel (negative).</field>
+      <field type="float" name="range" units="m">Max measurement range.</field>
+    </message>
+    <message id="13671" name="WIND_DATA_RAW">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+      <description>Wind data measurement message as interpreted through NMEA2000.</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="uint8_t" name="reference" enum="WIND_REFERENCE">Wind reference.</field>
+      <field type="float" name="wind_speed" units="m/s">Wind speed.</field>
+      <field type="float" name="wind_angle" units="rad">Wind angle.</field>
+    </message>
+    <!-- BOAT specific MAVLink-->
   </messages>
 </mavlink>

--- a/message_definitions/v1.0/auterion.xml
+++ b/message_definitions/v1.0/auterion.xml
@@ -417,17 +417,7 @@
       <field type="float[6]" name="engine_coolant_temperature" units="degC">Engine coolant temperature.</field>
       <field type="uint8_t[6]" name="transmission_state" enum="TRANSMISSION_STATE">Transmission state.</field>
     </message>
-    <message id="668" name="BOAT_BATTERY_STATUS">
-      <wip/>
-      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-      <description>Boat battery status reports battery status as interpreted through NMEA2000.</description>
-      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
-      <field type="uint8_t" name="instance">Battery instance.</field>
-      <field type="float" name="voltage" units="V">Battery voltage.</field>
-      <field type="float" name="current" units="A">Battery current.</field>
-      <field type="float" name="temperature" units="K">Battery temperature.</field>
-    </message>
-    <message id="669" name="BOAT_FLUID_LEVEL">
+    <message id="668" name="FLUID_LEVEL">
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Boat fluid level reports fluid levels as interpreted through NMEA2000.</description>
@@ -437,29 +427,29 @@
       <field type="float" name="level" units="%">Fluid level in percentage of full tank.</field>
       <field type="float" name="capacity" units="l">Fluid capacity left in tank in liters.</field>
     </message>
-    <message id="670" name="BOAT_SPEED">
+    <message id="669" name="VESSEL_SPEED">
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-      <description>Boat speed reports speeds as interpreted through NMEA2000.</description>
+      <description>Vessel speed measurement as interpreted through NMEA2000.</description>
       <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
       <field type="float" name="speed_water_referenced" units="m/s">Speed water referenced.</field>
       <field type="float" name="speed_ground_referenced" units="m/s">Speed ground referenced.</field>
       <field type="uint8_t" name="speed_water_referenced_type" enum="SPEED_WATER_REFERENCED_TYPE">Speed water referenced type.</field>
       <field type="uint8_t" name="speed_direction">Speed direction.</field>
     </message>
-    <message id="671" name="BOAT_WATER_DEPTH">
+    <message id="670" name="WATER_DEPTH">
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-      <description>Boat water depth reports water depth as interpreted through NMEA2000.</description>
+      <description>Water depth measurement data as interpreted through NMEA2000.</description>
       <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
       <field type="float" name="depth" units="m">Depth below transducer.</field>
       <field type="float" name="offset" units="m">Distance between transducer and surface (positive) or keel (negative).</field>
       <field type="float" name="range" units="m">Max measurement range.</field>
     </message>
-    <message id="672" name="BOAT_WIND_DATA">
+    <message id="671" name="WIND_DATA_RAW">
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-      <description>Boat wind data reports wind data as interpreted through NMEA2000..</description>
+      <description>Wind data measurement message as interpreted through NMEA2000.</description>
       <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
       <field type="uint8_t" name="reference" enum="WIND_REFERENCE">Wind reference.</field>
       <field type="float" name="wind_speed" units="m/s">Wind speed.</field>

--- a/message_definitions/v1.0/auterion.xml
+++ b/message_definitions/v1.0/auterion.xml
@@ -262,7 +262,7 @@
     </enum>
     <enum name="WIND_REFERENCE">
       <description>Specifies the frame of reference used for wind direction and speed measurements.</description>
-       <entry value="0" name="REFERENCE_TRUE">
+      <entry value="0" name="REFERENCE_TRUE">
         <description>REFERENCE_TRUE Wind referenced to geographic (true) North.</description>
       </entry>
       <entry value="1" name="REFERENCE_MAGNETIC">

--- a/message_definitions/v1.0/auterion.xml
+++ b/message_definitions/v1.0/auterion.xml
@@ -472,7 +472,7 @@
       <field type="uint8_t[6]" name="engine_state" enum="ENGINE_STATE">Engine state.</field>
       <field type="uint8_t[6]" name="engine_load" units="%">Engine load.</field>
       <field type="uint16_t[6]" name="engine_rpm" units="rpm">Engine RPM.</field>
-      <field type="float" name="fuel_consumption_rate" units="l/h">Fuel consumption rate.</field>
+      <field type="float" name="fuel_consumption_rate" units="L/h">Fuel consumption rate.</field>
       <field type="float[6]" name="oil_pressure" units="kPa">Engine oil pressure.</field>
       <field type="uint8_t[6]" name="throttle_position" units="%">Throttle position.</field>
       <field type="float[6]" name="engine_coolant_temperature" units="degC">Engine coolant temperature.</field>


### PR DESCRIPTION
This PR is mimicing the upstream PR against mavlink/mavlink(#2255).

Why?
This is because many of the boat specific fields and messages are subject to change, partially because we don't know enough at the time of writing and the created messages are purposefully designed to be very non-restrictive as a result. Also, the implementation associated with them is mostly on the CAN driver side, which stays as Auterion IP and will not be upstreamed.

Also AMC already supports these MAVLink definitinons, but they ought to be based on Auterion managed version control and not a private forks of mavlink repository.

### **Functional changes**
**[new enums]**

ENGINE_LEG_TRIM
- Defines the engine leg state, part of BOAT_ACTUATOR_STATUS message sent from a vehicle to the GCS.
- Data originates from J1939 CAN messages and the engine driver implementation.

ENGINE_STATE
- Defines the engine state, part of BOAT_ENGINE_STATUS message sent from a vehicle to the GCS.
- Data originates from J1939 CAN messages and the engine driver implementation.

RUDDER_STATE
- Defines the rudder state, part of BOAT_ACTUATOR_STATUS message sent from a vehicle to GCS. 
- Data originates from PCM CAN rudder messages and the pertaining driver implementation.

TRANSMISSION_STATE
- Defines transmission gear or state, part of BOAT_ENGINE_STATE message sent from  a vehicle to the GCS.
- Data originates from J1939 CAN messages and the engine driver implementation.

FLUID_TANK_TYPE
- Defines type of the the fluid tank. 
- Fields of the enumeration are created based on the NMEA2000 protocol definition.

SPEED_WATER_REFERENCED_TYPE
- Defines reference frame for the vessel speed measurement.
- Fields of the enumeration are created based on the NMEA2000 protocol definition.

WIND_REFERENCED
- Defines reference frame for the wind speed measurement.
- Fields of the enumeration are created based on the NMEA2000 protocol definition.


**[new telemetry streams]**

BOAT_ACTUATOR_STATUS
- This is a aggregate message for all control surfaces on the vehicle, i.e. rudders and engine trims. 
- This telemetry is streamed from a vessel to the GCS and is considered critical for safety.
- The data comes from J1939 and PCM CAN buses and their respective driver implementations.

BOAT_ENGINE_STATUS
- This telemetry is streamed from a vessel to the GCS and is considered critical for safety. 
- Data comes from J1939 CAN bus and the pertaining driver implementation.
- Logically overlapping with common/EFI_STATUS. EFI_STATUS has many more fields for which we don't have data, while missing the TRANSMISSION_STATE data altogether. 

~BOAT_BATTERY_STATUS~
- Deprecated in favor of common/BATTERY_STATUS or development/BATTERY_STATUS_V2.

FLUID_LEVEL
- Critical for reporting of fuel level and ballast water level right now. 
- Similar message that already exists: FUEL_STATUS

WATER_DEPTH_RAW
- Name contested with ardupilotmega.xml WATER_DEPTH message.
- ardupilot message contains more fields, some of which probably make a lot of sense.
- Also can be seen as a new type of DISTANCE_SENSOR

WIND_DATA_RAW
- This is a true meassurement from a wind vane/anemometer sensor, not an estimate.
- Logically associated with common.xml WIND_COV message.

**[new MAV commands]**

MAV_CMD_DO_CONTROL_TAKEOVER
- Command that transfers control from human operator to the Autopilot. Necessary for boats with humans on board, however useless for fully autonomous systems without the human controls onboard.
- It is sent by a GCS to the vehicle, most likely a throttle head CAN bus is the consumer of the message.
- It has no bearing on armed/disarmed state.

MAV_CMD_DO_ENGINE_LEG_TRIM
- Command for lowering or pulling up the engine leg.
- The command is sent from a GCS to the vehicle, most likely the throttle head CAN bus is the consumer of the message.

MAV_CMD_DO_SET_ENGINE_STATE
- Command for starting and stopping the engine.
- The command is sent from a GCS to the vehicle, most likely the engine button panel CAN bus is the consumer of the message. 

### **Non functional changes**

[fix] formatting trailing white spaces.