### PR TITLE
Change timestamp to frame ID in tracking selection commands

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2220,8 +2220,7 @@
         <param index="2" label="Point y" minValue="0" maxValue="1">Point to track y value (normalized 0..1, 0 is top, 1 is bottom).</param>
         <param index="3" label="Radius" minValue="0" maxValue="1">Point radius (normalized 0..1, 0 is one pixel, 1 is full image width).</param>
         <param index="4" label="Target Camera ID" minValue="0" maxValue="255" increment="1">Target camera ID. 7 to 255: MAVLink camera component id. 1 to 6 for cameras attached to the autopilot, which don't have a distinct component id. 0: all cameras. This is used to target specific autopilot-connected cameras. It is also used to target specific cameras when the MAV_CMD is used in a mission.</param>
-        <param index="5" label="Frame timestamp [0-3]" units="ns">Bytes 0-3 of a little-endian uint64_t Unix timestamp of the frame on which to initiate tracking.</param>
-        <param index="6" label="Frame timestamp [4-7]" units="ns">Bytes 4-7 of a little-endian uint64_t Unix timestamp of the frame on which to initiate tracking.</param>
+        <param index="5" label="Frame ID" minValue="0" maxValue="65535" increment="1">Identifier of the frame on which to initiate tracking.</param>
       </entry>
       <entry value="2005" name="MAV_CMD_CAMERA_TRACK_RECTANGLE" hasLocation="false" isDestination="false">
         <description>If the camera supports rectangle visual tracking (CAMERA_CAP_FLAGS_HAS_TRACKING_RECTANGLE is set), initiate tracking of a rectangular area in an image.</description>
@@ -2230,8 +2229,7 @@
         <param index="3" label="Bottom right corner x" minValue="0" maxValue="1">Bottom right corner of rectangle x value (normalized 0..1, 0 is left, 1 is right).</param>
         <param index="4" label="Bottom right corner y" minValue="0" maxValue="1">Bottom right corner of rectangle y value (normalized 0..1, 0 is top, 1 is bottom).</param>
         <param index="5" label="Target Camera ID" minValue="0" maxValue="255" increment="1">Target camera ID. 7 to 255: MAVLink camera component id. 1 to 6 for cameras attached to the autopilot, which don't have a distinct component id. 0: all cameras. This is used to target specific autopilot-connected cameras. It is also used to target specific cameras when the MAV_CMD is used in a mission.</param>
-        <param index="6" label="Frame timestamp [0-3]" units="ns">Bytes 0-3 of a little-endian uint64_t Unix timestamp of the frame on which to initiate tracking.</param>
-        <param index="7" label="Frame timestamp [4-7]" units="ns">Bytes 4-7 of a little-endian uint64_t Unix timestamp of the frame on which to initiate tracking.</param>
+        <param index="6" label="Frame ID" minValue="0" maxValue="65535" increment="1">Identifier of the frame on which to initiate tracking.</param>
       </entry>
       <entry value="2010" name="MAV_CMD_CAMERA_STOP_TRACKING" hasLocation="false" isDestination="false">
         <description>Stops ongoing tracking.</description>


### PR DESCRIPTION
### Description

Partially revert #293 to use an integer frame ID instead of a timestamp to identify frames in tracking selections.

The frame ID is a 16-bit integer between 0 and 65535, which can still be stored as a float - the type of the `MAV_CMD` params.

**Jira:** [CV-250](https://auterion.atlassian.net/browse/CV-250)

[CV-250]: https://auterion.atlassian.net/browse/CV-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ