### PR TITLE
[DRAFT] Feature/expand message mission executor

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -7953,6 +7953,7 @@
       <field type="uint8_t" name="standard_mode" enum="MAV_STANDARD_MODE">Standard mode.</field>
       <field type="uint32_t" name="custom_mode">A bitfield for use for autopilot-specific flags</field>
       <field type="uint32_t" name="intended_custom_mode" invalid="0">The custom_mode of the mode that was last commanded by the user (for example, with MAV_CMD_DO_SET_STANDARD_MODE, MAV_CMD_DO_SET_MODE or via RC). This should usually be the same as custom_mode. It will be different if the vehicle is unable to enter the intended mode, or has left that mode due to a failsafe condition. 0 indicates the intended custom mode is unknown/not supplied</field>
+      <field type="uint8_t" name="executor_in_charge">Current mode executor in charge (0=Autopilot)</field>
     </message>
     <message id="437" name="AVAILABLE_MODES_MONITOR">
       <description>A change to the sequence number indicates that the set of AVAILABLE_MODES has changed.


### PR DESCRIPTION
This new parameter is needed by the mission-executor context. It will map the executor_in_charge value in the UORB message vehicle_status.