### PR TITLE
auterion: add GLOBAL_POSITION message

### DIFF
--- a/message_definitions/v1.0/auterion.xml
+++ b/message_definitions/v1.0/auterion.xml
@@ -253,23 +253,17 @@
       <field type="uint8_t" name="current_payload_controller" enum="CURRENT_CONTROL_ENTITY">Current payload control entity.</field>
     </message>
     <message id="13296" name="GLOBAL_POSITION">
-    <!-- Replaces EXTERNAL_GLOBAL_POSITION -->
+      <!-- Replaces EXTERNAL_GLOBAL_POSITION -->
       <description>Global position measurement or estimate.</description>
       <field type="uint8_t" name="id" instance="true">Sensor ID</field>
       <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="uint8_t" name="source" enum="GLOBAL_POSITION_SRC">Source: 0 - unknown, 1 - GNSS, 2 - vision, 3 - pseudolites, 4 - estimator</field>
       <field type="int32_t" name="lat" units="degE7" invalid="INT32_MAX">Latitude (WGS84)</field>
       <field type="int32_t" name="lon" units="degE7" invalid="INT32_MAX">Longitude (WGS84)</field>
       <field type="float" name="alt" units="m" invalid="NaN">Altitude (MSL - position-system specific value)</field>
-      <field type="float" name="alt_ellipsoid" units="m" invalid="NaN">Altitude (WGS84)</field>
+      <field type="float" name="alt_ellipsoid" units="m" invalid="NaN">Altitude (WGS84 elipsoid)</field>
       <field type="float" name="eph" units="m" invalid="NaN">Standard deviation of horizontal position error</field>
       <field type="float" name="epv" units="m" invalid="NaN">Standard deviation of vertical position error</field>
-      <field type="float" name="vx" units="m/s" invalid="NaN">Ground X Speed (Latitude, positive north)</field>
-      <field type="float" name="vy" units="m/s" invalid="NaN">Ground Y Speed (Longitude, positive east)</field>
-      <field type="float" name="vz" units="m/s" invalid="NaN">Ground Z Speed (Altitude, positive down)</field>
-      <field type="float" name="h_sacc" units="m/s" invalid="NaN">Standard deviation of horizontal velocity error</field>
-      <field type="float" name="v_sacc" units="m/s" invalid="NaN">Standard deviation of vertical velocity error</field>
-      <field type="float" name="hdg" units="deg" minValue="0" maxValue="359.99" invalid="NaN">Vehicle heading (yaw angle). Range is 0.0..359.99 degrees relative to North.</field>
-      <field type="float" name="hdg_acc" units="deg" invalid="NaN">Standard deviation of heading error</field>
     </message>
     <message id="13442" name="REQUEST_CONTROL">
       <description>Request the flight control and/or the payload control of the target system by a GCS.

--- a/message_definitions/v1.0/auterion.xml
+++ b/message_definitions/v1.0/auterion.xml
@@ -252,6 +252,25 @@
       <field type="uint8_t" name="current_flight_controller" enum="CURRENT_CONTROL_ENTITY">Current flight control entity.</field>
       <field type="uint8_t" name="current_payload_controller" enum="CURRENT_CONTROL_ENTITY">Current payload control entity.</field>
     </message>
+    <message id="13296" name="GLOBAL_POSITION">
+    <!-- Replaces EXTERNAL_GLOBAL_POSITION -->
+      <description>Global position measurement or estimate.</description>
+      <field type="uint8_t" name="id" instance="true">Sensor ID</field>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="int32_t" name="lat" units="degE7" invalid="INT32_MAX">Latitude (WGS84)</field>
+      <field type="int32_t" name="lon" units="degE7" invalid="INT32_MAX">Longitude (WGS84)</field>
+      <field type="float" name="alt" units="m" invalid="NaN">Altitude (MSL - position-system specific value)</field>
+      <field type="float" name="alt_ellipsoid" units="m" invalid="NaN">Altitude (WGS84)</field>
+      <field type="float" name="eph" units="m" invalid="NaN">Standard deviation of horizontal position error</field>
+      <field type="float" name="epv" units="m" invalid="NaN">Standard deviation of vertical position error</field>
+      <field type="float" name="vx" units="m/s" invalid="NaN">Ground X Speed (Latitude, positive north)</field>
+      <field type="float" name="vy" units="m/s" invalid="NaN">Ground Y Speed (Longitude, positive east)</field>
+      <field type="float" name="vz" units="m/s" invalid="NaN">Ground Z Speed (Altitude, positive down)</field>
+      <field type="float" name="h_sacc" units="m/s" invalid="NaN">Standard deviation of horizontal velocity error</field>
+      <field type="float" name="v_sacc" units="m/s" invalid="NaN">Standard deviation of vertical velocity error</field>
+      <field type="float" name="hdg" units="deg" minValue="0" maxValue="359.99" invalid="NaN">Vehicle heading (yaw angle). Range is 0.0..359.99 degrees relative to North.</field>
+      <field type="float" name="hdg_acc" units="deg" invalid="NaN">Standard deviation of heading error</field>
+    </message>
     <message id="13442" name="REQUEST_CONTROL">
       <description>Request the flight control and/or the payload control of the target system by a GCS.
         The message can be used in a multi GCS environment. A GCS can request the control ownership of the target system. 

--- a/message_definitions/v1.0/auterion.xml
+++ b/message_definitions/v1.0/auterion.xml
@@ -91,6 +91,30 @@
         <description>Error Code indicating no enough priority authority control ownership.</description>
       </entry>
     </enum>
+    <enum name="GLOBAL_POSITION_SRC">
+      <description>Selection of control target for changing ownership.</description>
+      <entry value="0" name="unknown">
+        <description>Source is either unkown or not listed in this enum.</description>
+      </entry>
+      <entry value="1" name="GNSS">
+        <description>Global Navigation Satellite System (e.g.: GPS, Galileo, Glonass, BeiDou).</description>
+      </entry>
+      <entry value="2" name="vision">
+        <description>Vision system (e.g.: map matching).</description>
+      </entry>
+      <entry value="3" name="pseudolites">
+        <description>Beacon-based system different than GNSS.</description>
+      </entry>
+      <entry value="4" name="TRN">
+        <description>Terrain Referenced Navigation.</description>
+      </entry>
+      <entry value="5" name="Magnetic">
+        <description>Magnetic positioning.</description>
+      </entry>
+      <entry value="6" name="estimator">
+        <description>Estimated position based on various sensors.</description>
+      </entry>
+    </enum>
     <enum name="HANDOFF_DECISION">
       <description>Decision of the GCS to a handoff request.</description>
       <entry value="0" name="HANDOFF_DECISION_ACCEPT">
@@ -257,7 +281,7 @@
       <description>Global position measurement or estimate.</description>
       <field type="uint8_t" name="id" instance="true">Sensor ID</field>
       <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
-      <field type="uint8_t" name="source" enum="GLOBAL_POSITION_SRC">Source: 0 - unknown, 1 - GNSS, 2 - vision, 3 - pseudolites, 4 - estimator</field>
+      <field type="uint8_t" name="source" enum="GLOBAL_POSITION_SRC">Source: 0 - unknown, 1 - GNSS, 2 - vision, 3 - pseudolites, 4 - TRN, 5 - magnetic, 6 - estimator</field>
       <field type="int32_t" name="lat" units="degE7" invalid="INT32_MAX">Latitude (WGS84)</field>
       <field type="int32_t" name="lon" units="degE7" invalid="INT32_MAX">Longitude (WGS84)</field>
       <field type="float" name="alt" units="m" invalid="NaN">Altitude (MSL - position-system specific value)</field>


### PR DESCRIPTION
This is to replace EXTERNAL_GLOBAL_POSITION until we have an upstream version of it.
EXTERNAL_GLOBAL_POSITION was introduced here: https://github.com/Auterion/mavlink/pull/281
The plan is to get the `GLOBAL_POSITION` merged upstream, but until then, we decided to have it in the Auterion dialect.
upsteam PR: https://github.com/mavlink/mavlink/pull/2256