### PR TITLE
Add new component IDs for the ARF radios in the auterion dialect

### DIFF
--- a/message_definitions/v1.0/minimal.xml
+++ b/message_definitions/v1.0/minimal.xml
@@ -565,6 +565,15 @@
       <entry value="105" name="MAV_COMP_ID_CAMERA6">
         <description>Camera #6.</description>
       </entry>
+      <entry value="110" name="MAV_COMP_ID_RADIO">
+        <description>Radio #1.</description>
+      </entry>
+      <entry value="111" name="MAV_COMP_ID_RADIO2">
+        <description>Radio #2.</description>
+      </entry>
+      <entry value="112" name="MAV_COMP_ID_RADIO3">
+        <description>Radio #3.</description>
+      </entry>
       <entry value="140" name="MAV_COMP_ID_SERVO1">
         <description>Servo #1.</description>
       </entry>


### PR DESCRIPTION
Add 3 new component IDs in the `MAV_COMPONENT` enum:
- `MAV_COMP_ID_RADIO=110, /* Radio #1. | */`
- `MAV_COMP_ID_RADIO2=111, /* Radio #2. | */`
- `MAV_COMP_ID_RADIO3=112, /* Radio #3. | */`

Use the space between `MAV_COMP_ID_CAMERA6=105` and `MAV_COMP_ID_SERVO1=140` because it leaves a big gap in between in case we need to add new values in the future. 

The primary use of the new IDs is to identify the `RADIO_STATUS` message that comes from each individual radio. 

Upstream PR: https://github.com/mavlink/mavlink/pull/2327
