### PR TITLE
Update parachute message definition to latest

### DIFF
--- a/message_definitions/v1.0/auterion.xml
+++ b/message_definitions/v1.0/auterion.xml
@@ -332,7 +332,7 @@
     <enum name="PARACHUTE_DEPLOYMENT_TRIGGER">
       <description>Parachute deployment trigger source</description>
       <entry value="0" name="PARACHUTE_DEPLOYMENT_TRIGGER_NONE">
-        <description>None (parachute has not deployed)</description>
+        <description>None - not triggered automatically</description>
       </entry>
       <entry value="1" name="PARACHUTE_DEPLOYMENT_TRIGGER_MANUAL">
         <description>Manual</description>


### PR DESCRIPTION
On Slack we were notified about the latest developlment.xml message definition for the parachute (attached to this PR).

This commit brings in the differences.

[development.xml](https://github.com/user-attachments/files/22844731/development.xml)
