### PR TITLE
update(common.xml): Add sinr to cellular status

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -7753,6 +7753,7 @@
       <field type="uint16_t" name="ber" invalid="0">(WIP) The bit error rate (BER) is determined by comparing the erroneous bits received with the total number of bits received. It is a ratio.</field>
       <field type="uint8_t" name="id" instance="true" invalid="0">(WIP) Cellular instance number. Indexed from 1. Matches index in corresponding CELLULAR_MODEM_INFORMATION message.</field>
       <field type="char[9]" name="cell_tower_id" invalid="0">(WIP) ID of the currently connected cell tower. This must be NULL terminated if the length is less than 9 human-readable chars, and without the null termination (NULL) byte if the length is exactly 9 chars.</field>
+      <field type="float" name="sinr" units="dB" invalid="0">(WIP) Signal to interference plus noise ratio (SINR).</field>
     </message>
     <message id="335" name="ISBD_LINK_STATUS">
       <description>Status of the Iridium SBD link.</description>


### PR DESCRIPTION
**Decsription**
LTE module has an additional piece of information which is useful for LTE statistics: SINR: Signal-to-Interference-plus-Noise Ratio. Currently, this information is not part of the CELLULAR_STATUS message.

**Solution**
Add sinr field to the CELLULAR_STATUS message as the last extension topic. By adding it as the last extension topic (which are unordered), this should not break consumers of these messages who are unaware of the updated message definition.