### PR TITLE
feat(auterion): add apps status message

### DIFF
--- a/message_definitions/v1.0/auterion.xml
+++ b/message_definitions/v1.0/auterion.xml
@@ -479,6 +479,21 @@
         <description>Device has reported an error. Requires an explicit reset before it can be re-enabled.</description>
       </entry>
     </enum>
+    <enum name="APPS_HEALTH_STATE">
+      <entry value="0" name="APPS_HEALTH_OK"/>
+      <entry value="1" name="APPS_HEALTH_UNKNOWN"/>
+      <entry value="2" name="APPS_HEALTH_ERROR"/>
+    </enum>
+    <enum name="APP_HEALTH_FLAGS" bitmask="true">
+      <description>
+        Bitmask describing application health failures.
+        Used both per-app and aggregated across all apps.
+      </description>
+      <entry value="1" name="APP_NOT_INSTALLED"/>
+      <entry value="2" name="APP_NOT_RUNNING"/>
+      <entry value="4" name="APP_VERSION_MISMATCH"/>
+      <entry value="8" name="APP_CONFIG_MISMATCH"/>
+    </enum>
   </enums>
   <messages>
     <!-- Transactions for parameter protocol -->
@@ -751,6 +766,23 @@
       <field type="uint32_t" name="countdown" units="s">Countdown timer value for SST or other timed state.</field>
       <field type="uint8_t" name="mode">Mode; this can be a sub-state within the current state or other indicator. This may vary based on device and state.</field>
       <field type="char[64]" name="message">Message, or other text from device.</field>
+    </message>
+    <message id="13801" name="ONBOARD_COMPUTER_APPS_STATUS">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+      <description>
+        Aggregated health summary of default AOS bundled applications.
+        failure_flags is the OR-combination of all failing apps.
+      </description>
+      <field type="uint8_t" name="overall_health" enum="APPS_HEALTH_STATE">
+        Overall system health state
+      </field>
+      <field type="uint8_t" name="failure_flags" enum="APP_HEALTH_FLAGS">
+        Bitmask of detected failure types across all default bundled apps
+      </field>
+      <field type="uint8_t" name="failing_apps_count">
+        Number of default bundled apps in failure state
+      </field>
     </message>
   </messages>
 </mavlink>


### PR DESCRIPTION
### Changes

This introduces the auterion dialect message `ONBOARD_COMPUTER_APPS_STATUS`. Its purpose is to provide a global health check of AOS apps' statuses. This message is designed to be published periodically (low frequency) by the mission computer.

This message only offers a global app health check, it does not provide traceability for failing global checks.

See [the design document](https://auterion.atlassian.net/wiki/spaces/ENG/pages/4387012669/Apps+Preflight+Check+in+AMC+-+Design+Document); it describes this messages, and future messages that can be added for apps' health failure traceability.

### Related PRs:

- Used by **`mavlink-bridge.service`**  to fetch apps' statuses and publish those over MAVLink: https://github.com/Auterion/mavlink-bridge/pull/14