### PR TITLE
Fix TRACKER_DETECTION_2D field bugs

### DIFF
--- a/message_definitions/v1.0/auterion.xml
+++ b/message_definitions/v1.0/auterion.xml
@@ -563,8 +563,8 @@
       <field type="uint16_t" name="bbox_top_left_y" units="c%"> Relative image y coordinate (top to bottom axis) in the range of [0.00, 100.00] describing the top left corner of the bounding box.</field>
       <field type="uint16_t" name="bbox_bot_right_x" units="c%"> Relative image x coordinate (left to right axis) in the range of [0.00, 100.00] describing the bottom right corner of the bounding box.</field>
       <field type="uint16_t" name="bbox_bot_right_y" units="c%"> Relative image y coordinate (top to bottom axis) in the range of [0.00, 100.00] describing the bottom left corner of the bounding box.</field>
-      <field type="int32_t" name="lat" units="degE7" invalid="UINT32_MAX"> Latitude in WGS84 coordinate frame of the detected object. NAN if unknown.</field>
-      <field type="int32_t" name="lon" units="degE7" invalid="UINT32_MAX"> Longitude in WGS84 coordinate frame of the detected object. NAN if unknown.</field>
+      <field type="int32_t" name="lat" units="degE7" invalid="INT32_MAX"> Latitude in WGS84 coordinate frame of the detected object. INT32_MAX if unknown.</field>
+      <field type="int32_t" name="lon" units="degE7" invalid="INT32_MAX"> Longitude in WGS84 coordinate frame of the detected object. INT32_MAX if unknown.</field>
       <field type="float" name="alt" units="m" invalid="[NaN:]"> Altitude in EGM96 coordiante frame of the detected object. NAN if unknown.</field>
       <field type="float" name="vel_n" units="m/s" invalid="[NaN:]"> North velocity of the object in global frame. NAN if unknown.</field>
       <field type="float" name="vel_e" units="m/s" invalid="[NaN:]"> East velocity of the object in global frame. NAN if unknown.</field>

--- a/message_definitions/v1.0/auterion.xml
+++ b/message_definitions/v1.0/auterion.xml
@@ -562,10 +562,10 @@
       <field type="uint16_t" name="bbox_top_left_x" units="c%"> Relative image x coordinate (left to right axis) in the range of [0.00, 100.00] describing the top left corner of the bounding box .</field>
       <field type="uint16_t" name="bbox_top_left_y" units="c%"> Relative image y coordinate (top to bottom axis) in the range of [0.00, 100.00] describing the top left corner of the bounding box.</field>
       <field type="uint16_t" name="bbox_bot_right_x" units="c%"> Relative image x coordinate (left to right axis) in the range of [0.00, 100.00] describing the bottom right corner of the bounding box.</field>
-      <field type="uint16_t" name="bbox_bot_right_y" units="c%"> Relative image y coordinate (top to bottom axis) in the range of [0.00, 100.00] describing the bottom left corner of the bounding box.</field>
+      <field type="uint16_t" name="bbox_bot_right_y" units="c%"> Relative image y coordinate (top to bottom axis) in the range of [0.00, 100.00] describing the bottom right corner of the bounding box.</field>
       <field type="int32_t" name="lat" units="degE7" invalid="INT32_MAX"> Latitude in WGS84 coordinate frame of the detected object. INT32_MAX if unknown.</field>
       <field type="int32_t" name="lon" units="degE7" invalid="INT32_MAX"> Longitude in WGS84 coordinate frame of the detected object. INT32_MAX if unknown.</field>
-      <field type="float" name="alt" units="m" invalid="[NaN:]"> Altitude in EGM96 coordiante frame of the detected object. NAN if unknown.</field>
+      <field type="float" name="alt" units="m" invalid="[NaN:]"> Altitude in EGM96 coordinate frame of the detected object. NAN if unknown.</field>
       <field type="float" name="vel_n" units="m/s" invalid="[NaN:]"> North velocity of the object in global frame. NAN if unknown.</field>
       <field type="float" name="vel_e" units="m/s" invalid="[NaN:]"> East velocity of the object in global frame. NAN if unknown.</field>
       <field type="float" name="vel_up" units="m/s" invalid="[NaN:]"> Up velocity of the object in global frame. NAN if unknown.</field>


### PR DESCRIPTION
`TRACKER_DETECTION_2D` (msg 501) had three bugs in `auterion.xml`:

- **Wrong invalid sentinel on `lat`/`lon`** — `invalid="UINT32_MAX"` on `int32_t` fields forces the bit pattern `0xFFFFFFFF` which reads back as `−1`, i.e. `−0.0000001°` — a valid coordinate near Null Island. Changed to `INT32_MAX`, which is outside the representable `degE7` range (±1 800 000 000).
- **Incorrect "NAN if unknown" description on integer fields** — copy-pasted from the adjacent `float` fields. Corrected to "INT32_MAX if unknown."
- **`bbox_bot_right_y` description said "bottom left corner"** — should be "bottom right". The other three bbox fields were correct.
- **Typo in `alt` description** — "coordiante" → "coordinate".