### PR TITLE
fix(boat): new name for dual compatibility issue

### DIFF
--- a/message_definitions/v1.0/auterion.xml
+++ b/message_definitions/v1.0/auterion.xml
@@ -656,7 +656,7 @@
       <field type="char[32]" name="uuid">uuid of the sender.</field>
     </message>
     <!-- Boat specific MAVLink-->
-    <message id="13666" name="BOAT_ACTUATOR_STATUS">
+    <message id="13666" name="BOAT_ACTUATOR_STATUS_NEW">
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Boat actuator status reports status and position of all boat control surfaces (currently rudders, engine leg trims).</description>
@@ -666,7 +666,7 @@
       <field type="uint8_t[6]" name="rudder_state" enum="RUDDER_STATE">Rudder state.</field>
       <field type="float[6]" name="rudder_position" units="deg">Rudder position.</field>
     </message>
-    <message id="13667" name="BOAT_ENGINE_STATUS">
+    <message id="13667" name="BOAT_ENGINE_STATUS_NEW">
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Boat engine status reports status and position of all boat engines.</description>

--- a/message_definitions/v1.0/auterion.xml
+++ b/message_definitions/v1.0/auterion.xml
@@ -656,7 +656,7 @@
       <field type="char[32]" name="uuid">uuid of the sender.</field>
     </message>
     <!-- Boat specific MAVLink-->
-    <message id="13666" name="BOAT_ACTUATOR_STATUS_NEW">
+    <message id="13666" name="BOAT_ACTUATOR_STATUS_V2">
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Boat actuator status reports status and position of all boat control surfaces (currently rudders, engine leg trims).</description>
@@ -666,7 +666,7 @@
       <field type="uint8_t[6]" name="rudder_state" enum="RUDDER_STATE">Rudder state.</field>
       <field type="float[6]" name="rudder_position" units="deg">Rudder position.</field>
     </message>
-    <message id="13667" name="BOAT_ENGINE_STATUS_NEW">
+    <message id="13667" name="BOAT_ENGINE_STATUS_V2">
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Boat engine status reports status and position of all boat engines.</description>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -582,8 +582,8 @@
       <wip since="2026-03"/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>
-        Highly bandwidth-efficient RC override message for professional networked operations (LTE, Zigbee, GCP). 
-        Supersedes RC_CHANNELS_OVERRIDE by adding 32-channel support and a bitmask for multi-master conflict avoidance. 
+        Highly bandwidth-efficient RC override message for professional networked operations (LTE, Zigbee, GCP).
+        Supersedes RC_CHANNELS_OVERRIDE by adding 32-channel support and a bitmask for multi-master conflict avoidance.
         Uses centered-at-zero values and extension-field placement to maximize MAVLink 2 trailing-zero truncation.
       </description>
       <field type="uint8_t" name="target_system">System ID.</field>
@@ -591,8 +591,8 @@
       <field type="uint32_t" name="active_mask">Bitmap of included channels (bit 0 = CH1). 1: Valid/Override, 0: Ignore.</field>
       <extensions/>
       <field type="int16_t[32]" name="channels" minValue="-4096" maxValue="4096">
-        RC channels in centered 13-bit format. Range: -4096 to 4096, Center: 0. 
-        Conversion to PWM: (x * 5/32) + 1500. 
+        RC channels in centered 13-bit format. Range: -4096 to 4096, Center: 0.
+        Conversion to PWM: (x * 5/32) + 1500.
         Unused channels must be set to 0 to enable MAVLink 2 trailing-zero trimming.
       </field>
     </message>


### PR DESCRIPTION
# Issue
Boat messages were moved to new id range, creating a mess of compatibility between old and new releases. A transition AMC version was created that supported old and new IDs. However to make that possible the name had to be different, therefore introduction of "V2".

# Result
Now dual compatibility is gone, but we are left with new names.