### PR TITLE
feat(auterion): add ONBOARD_COMPUTER_APP_HEALTH message

### DIFF
--- a/message_definitions/v1.0/auterion.xml
+++ b/message_definitions/v1.0/auterion.xml
@@ -767,7 +767,7 @@
       <field type="uint8_t" name="mode">Mode; this can be a sub-state within the current state or other indicator. This may vary based on device and state.</field>
       <field type="char[64]" name="message">Message, or other text from device.</field>
     </message>
-    <message id="13801" name="ONBOARD_COMPUTER_APPS_STATUS">
+    <message id="13801" name="AOS_BUNDLED_APP_HEALTH_SUMMARY">
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>
@@ -782,17 +782,17 @@
       </field>
       <field type="uint8_t" name="total_apps_count">
         Total number of default bundled apps tracked (number of
-        ONBOARD_COMPUTER_APP_HEALTH messages to expect on request)
+        AOS_BUNDLED_APP_HEALTH messages to expect on request)
       </field>
     </message>
-    <message id="13802" name="ONBOARD_COMPUTER_APP_HEALTH">
+    <message id="13802" name="AOS_BUNDLED_APP_HEALTH">
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>
         Health of a single default AOS bundled application.
         Sent on request, one message per bundled app (a burst covering the full set).
         A healthy app reports failure_flags = 0. The recipient can use total_apps_count
-        from ONBOARD_COMPUTER_APPS_STATUS to detect a truncated burst and re-request.
+        from AOS_BUNDLED_APP_HEALTH_SUMMARY to detect a truncated burst and re-request.
       </description>
       <field type="char[128]" name="app_name">
         Name of the application

--- a/message_definitions/v1.0/auterion.xml
+++ b/message_definitions/v1.0/auterion.xml
@@ -780,8 +780,31 @@
       <field type="uint8_t" name="failure_flags" enum="APP_HEALTH_FLAGS">
         Bitmask of detected failure types across all default bundled apps
       </field>
-      <field type="uint8_t" name="failing_apps_count">
-        Number of default bundled apps in failure state
+      <field type="uint8_t" name="total_apps_count">
+        Total number of default bundled apps tracked (number of
+        ONBOARD_COMPUTER_APP_HEALTH messages to expect on request)
+      </field>
+    </message>
+    <message id="13802" name="ONBOARD_COMPUTER_APP_HEALTH">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+      <description>
+        Health of a single default AOS bundled application.
+        Sent on request, one message per bundled app (a burst covering the full set).
+        A healthy app reports failure_flags = 0. The recipient can use total_apps_count
+        from ONBOARD_COMPUTER_APPS_STATUS to detect a truncated burst and re-request.
+      </description>
+      <field type="char[128]" name="app_name">
+        Name of the application
+      </field>
+      <field type="uint8_t" name="failure_flags" enum="APP_HEALTH_FLAGS">
+        Bitmask of failure reasons for this application (0 = healthy)
+      </field>
+      <field type="char[32]" name="expected_version">
+        Expected bundled version
+      </field>
+      <field type="char[32]" name="actual_version">
+        Actual installed/running version
       </field>
     </message>
   </messages>


### PR DESCRIPTION
Renames `ONBOARD_COMPUTER_APPS_STATUS` -> `AOS_BUNDLED_APP_HEALTH`

Adds `AOS_BUNDLED_APP_HEALTH` (msg 13802): per-app health for the default AOS bundled apps (app name, failure flags, expected/actual version), sent on request as a burst of one message per bundled app — a healthy app reports failure_flags = 0.

Also updates the aggregate `AOS_BUNDLED_APP_HEALTH_SUMMARY` (13801): failing_apps_count becomes total_apps_count, so the receiver can size the burst and detect a truncated one.

Stacks on the apps-status branch (#375). Part of SW-293.
